### PR TITLE
chore(deps): Update @types/express to ^4.17.21 to avoid typing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rehooks/component-size": "^1.0.2",
     "@types/cors": "^2.8.4",
-    "@types/express": "^4.16.1",
+    "@types/express": "^4.17.21",
     "@types/jest": "^29.0.0",
     "@types/node": "^10.17.28",
     "@types/react": "^18.0.0",


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46639