### PR TITLE
Fix firmware version - call port.open() before querying it

### DIFF
--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -24,7 +24,7 @@ export class EBB {
 
   public constructor(port: SerialPort) {
     this.port = port;
-    this.writer = this.port.writable.getWriter()
+    this.writer = this.port.writable.getWriter();
     this.commandQueue = [];
     this.readableClosed = port.readable
       .pipeThrough(new RegexParser({ regex: /[\r\n]+/ }))

--- a/src/server.ts
+++ b/src/server.ts
@@ -288,11 +288,13 @@ async function* ebbs(path?: string) {
 
 export async function connectEBB(path: string | undefined): Promise<EBB | null> {
   if (path) {
-    return new EBB(new SerialPortSerialPort(path));
+    const port = await tryOpen(path);
+    return new EBB(port);
   } else {
     const ebbs = await listEBBs();
     if (ebbs.length) {
-      return new EBB(new SerialPortSerialPort(ebbs[0]));
+      const port = await tryOpen(ebbs[0]);
+      return new EBB(port);
     } else {
       return null;
     }


### PR DESCRIPTION
Closes #124 ... mostly.

The CLI will still throw an error (`throw new Error("TODO")`), but it will at least print the 
firmware version before doing so.

```
❯ npx . --firmware-version
EBBv13_and_above EB Firmware Version 2.8.1
/Users/a.ruddick/Documents/github/saxi/dist/server/ebb.js:73
            throw new Error("TODO");
```
