### PR TITLE
Add pen cli command to move the pen to a percent position

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import {flattenSVG} from "flatten-svg";
 import { Vec2 } from "./vec";
 import { formatDuration } from "./util";
-import { PlanOptions, defaultPlanOptions } from "./planning";
+import { PlanOptions, defaultPlanOptions, AxidrawFast, Device } from "./planning";
 import { PaperSize } from "./paper-size";
 
 function parseSvg(svg: string) {
@@ -246,6 +246,21 @@ export function cli(argv: string[]): void {
         await ebb.close()
       }
     )
+    .command('pen [percent]', 'put the pen to [percent]', yargs => yargs
+      .positional('percent', { type: 'number', description: 'percent height between 0 and 100', required: true})
+      .check(args => args.percent >= 0 && args.percent <= 100),
+    async args => {
+      console.log('connecting to plotter...')
+      const ebb = await connectEBB(args.device)
+      if (!ebb) {
+        console.error("Couldn't connect to device!")
+        process.exit(1)
+      }
+      await ebb.setPenHeight(Device.Axidraw.penPctToPos(args.percent), 1000)
+
+      console.log(`moving to ${args.percent}%...`)
+      await ebb.close()
+    })
     .parse(argv);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import {flattenSVG} from "flatten-svg";
 import { Vec2 } from "./vec";
 import { formatDuration } from "./util";
-import { PlanOptions, defaultPlanOptions, AxidrawFast, Device } from "./planning";
+import { Device, PlanOptions, defaultPlanOptions } from "./planning";
 import { PaperSize } from "./paper-size";
 
 function parseSvg(svg: string) {


### PR DESCRIPTION
I cannot test this in isolation until brushless support is merged, but should be harmless as is.