### PR TITLE
minify js bundle from 1.2mb to 0.3mb

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -7,6 +7,7 @@ const buildOptions = {
   bundle: true,
   platform: 'browser',
   target: 'es2020',
+  minify: true,
   sourcemap: true,
   metafile: true,
   logLevel: 'debug',


### PR DESCRIPTION
Since we create source maps, this should be fine
