### PR TITLE
UI tweaks

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -119,7 +119,7 @@ path {
   flex: 0 0 var(--panel-width);
   width: var(--panel-width);
   background-color: white;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   box-shadow: 3px 3px 15px rgba(0, 0, 0, 0.2);
 }
@@ -150,7 +150,7 @@ path {
 
 .section-header {
   margin-bottom: 1rem;
-  padding: 1rem 0;
+  padding: 0.5rem 0;
   border-bottom: 1px solid var(--purple-light);
   font-size: 18px;
   font-weight: 900;
@@ -163,6 +163,11 @@ path {
 }
 
 /* INPUTS */
+
+form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
 
 label {
   font-size: 10px;
@@ -281,7 +286,6 @@ select[multiple]:focus option:checked {
 .flex-checkbox {
   display: flex;
   align-items: center;
-  justify-content: center;
   margin-bottom: 0.5rem;
 }
 
@@ -315,7 +319,7 @@ select[multiple]:focus option:checked {
 }
 
 .layer-select {
-  height: 50px;
+  height: 100px;
   background-color: white;
   border: 1px solid var(--purple);
   color: var(--purple);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -855,40 +855,42 @@ function ResetToDefaultsButton() {
 function PlanOptions({state}: {state: State}) {
   const dispatch = useContext(DispatchContext);
   return <div>
-    <label className="flex-checkbox" title="Re-order paths to minimize pen-up travel time">
-      <input
-        type="checkbox"
-        checked={state.planOptions.sortPaths}
-        onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {sortPaths: !!e.target.checked}})}
-      />
-      sort paths
-    </label>
-    <label className="flex-checkbox" title="Re-scale and position the image to fit on the page">
-      <input
-        type="checkbox"
-        checked={state.planOptions.fitPage}
-        onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {fitPage: !!e.target.checked}})}
-      />
-      fit page
-    </label>
-    {!state.planOptions.fitPage ?
-      <label className="flex-checkbox" title="Remove lines that fall outside the margins">
+    <form>
+      <label className="flex-checkbox" title="Re-order paths to minimize pen-up travel time">
         <input
           type="checkbox"
-          checked={state.planOptions.cropToMargins}
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {cropToMargins: !!e.target.checked}})}
+          checked={state.planOptions.sortPaths}
+          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {sortPaths: !!e.target.checked}})}
         />
-        crop to margins
+        sort paths
       </label>
-      : null}
-    <label className="flex-checkbox" title="Split into layers according to group ID, instead of stroke">
-      <input
-        type="checkbox"
-        checked={state.planOptions.layerMode === 'group'}
-        onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {layerMode: e.target.checked ? 'group' : 'stroke'}})}
-      />
-      layer by group
-    </label>
+      <label className="flex-checkbox" title="Split into layers according to group ID, instead of stroke">
+        <input
+          type="checkbox"
+          checked={state.planOptions.layerMode === 'group'}
+          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {layerMode: e.target.checked ? 'group' : 'stroke'}})}
+        />
+        layer by group
+      </label>
+      <label className="flex-checkbox" title="Re-scale and position the image to fit on the page">
+        <input
+          type="checkbox"
+          checked={state.planOptions.fitPage}
+          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {fitPage: !!e.target.checked}})}
+        />
+        fit page
+      </label>
+      {!state.planOptions.fitPage ?
+        <label className="flex-checkbox" title="Remove lines that fall outside the margins">
+          <input
+            type="checkbox"
+            checked={state.planOptions.cropToMargins}
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {cropToMargins: !!e.target.checked}})}
+          />
+          crop to margins
+        </label>
+        : null}
+    </form>
     <div className="horizontal-labels">
 
       <label title="point-joining radius (mm)" >


### PR DESCRIPTION
- [x] Increase size of layer multi-select dropdown
- [x] Hide scrollbar gutter when there's no scrollbar
- [x] Organize plotting buttons into a grid
- [ ] Better styling for layer dropdown

Before: ugly unaligned buttons
![Screenshot 2023-10-12 at 5 28 03 PM](https://github.com/alexrudd2/saxi/assets/52292902/e356a423-39fa-4115-839f-bfa53c5d3c4c)
After: button grid
(Note `Crop to margins` is only visible if `Fit page` is not selected, hence the re-order)
![Screenshot 2023-10-12 at 5 23 55 PM](https://github.com/alexrudd2/saxi/assets/52292902/46cd6006-6c68-4d13-8746-45879ae79ce8)



Before: scrollbar gutter is always present
![Screenshot 2023-10-12 at 5 27 38 PM](https://github.com/alexrudd2/saxi/assets/52292902/a2180fb9-c13a-4f49-9fa6-c8ec40dfe940)
After: scrollbar gutter is gone when no scrolling is needed
![Screenshot 2023-10-12 at 5 24 33 PM](https://github.com/alexrudd2/saxi/assets/52292902/fa14dd1c-971f-4c01-869e-20f6be6ec8a8)



Before: view only 2 layers at once
![Screenshot 2023-10-12 at 5 28 39 PM](https://github.com/alexrudd2/saxi/assets/52292902/796d776a-b389-45fb-a90b-4dd3751575ad)

After: view 4 at once
![Screenshot 2023-10-12 at 5 25 39 PM](https://github.com/alexrudd2/saxi/assets/52292902/f0f30dcb-11bc-4862-83b0-858d68aeac9a)



