### PR TITLE
fix multiple connects

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -240,7 +240,7 @@ class SaxiDriver implements Driver {
 
     const websocketProtocol = document.location.protocol === "https:" ? "wss" : "ws";
     this.socket = new WebSocket(`${websocketProtocol}://${document.location.host}/chat`);
-    
+
     this.socket.addEventListener("open", () => {
       console.log(`Connected to EBB server.`);
       this.connected = true;
@@ -1046,9 +1046,18 @@ function PortSelector({driver, setDriver}: {driver: Driver; setDriver: (d: Drive
 }
 
 function Root() {
-  const [driver, setDriver] = useState(
-    IS_WEB ? null as Driver | null : SaxiDriver.connect()
-  )
+  const [driver, setDriver] = useState<Driver | null>(null);
+  const [isDriverConnected, setIsDriverConnected] = useState(false);
+  useEffect(() => {
+    if (isDriverConnected) return
+    if (IS_WEB) {
+      setDriver(null as Driver);
+    } else {
+      setDriver(SaxiDriver.connect());
+    }
+    setIsDriverConnected(true);
+  }, [isDriverConnected]);
+
   const [state, dispatch] = useReducer(reducer, initialState);
   const [isPlanning, plan, setPlan] = usePlan(state.paths, state.planOptions);
   const [isLoadingFile, setIsLoadingFile] = useState(false);
@@ -1077,7 +1086,7 @@ function Root() {
     driver.onplan = (plan: Plan) => {
       setPlan(plan);
     };
-  }, [driver])
+  }, IS_WEB ? [driver] : [])
 
   useEffect(() => {
     const ondrop = (e: DragEvent) => {
@@ -1120,7 +1129,7 @@ function Root() {
       document.body.removeEventListener("dragleave", ondragleave);
       document.removeEventListener("paste", onpaste);
     };
-  });
+  }, []);
 
   // Each time new motion is started, save the start time
   const currentMotionStartedTime = useMemo(() => {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1086,7 +1086,7 @@ function Root() {
     driver.onplan = (plan: Plan) => {
       setPlan(plan);
     };
-  }, IS_WEB ? [driver] : [])
+  }, [driver])
 
   useEffect(() => {
     const ondrop = (e: DragEvent) => {


### PR DESCRIPTION
The event listeners for drag-n-drop don't need to be called multiple times, so pass `[]` as the second argument to `useEffect`.

~~The event listeners for the driver (probably) don't need to be called multiple times, so do it only for WebSerial (`IS_WEB==true`).~~ revert, this breaks ping/pong

Wrap the `SaxiDriver.connect()` call in a flag so it doesn't get called multiple times in `Root()`.
