### PR TITLE
Add brushless hardware support

### DIFF
--- a/src/__tests__/planning.test.ts
+++ b/src/__tests__/planning.test.ts
@@ -2,11 +2,10 @@ import {Plan, plan, Device, AxidrawFast, XYMotion, PenMotion, defaultPlanOptions
 import {Vec2} from '../vec';
 
 describe("plan", () => {
-  const device = Device.Axidraw
+  const device = Device()
   const positions = {
     up: AxidrawFast.penUpPos,
-    down: AxidrawFast.penDownPos,
-    zero: device.penPctToPos(0)
+    down: AxidrawFast.penDownPos
   }
   it.skip("handles an empty input", () => {
     expect(plan([], AxidrawFast)).toEqual(new Plan([]))
@@ -31,7 +30,7 @@ describe("plan", () => {
     expect(xyMotions(p)).toEqual([
       {from: {x: 0, y: 0}, to: {x: 10, y: 10}, penPos: 0},
       {from: {x: 10, y: 10}, to: {x: 10, y: 10}, penPos: positions.down},
-      {from: {x: 10, y: 10}, to: {x: 0, y: 0}, penPos: positions.zero},
+      {from: {x: 10, y: 10}, to: {x: 0, y: 0}, penPos: positions.up},
     ]);
   });
 
@@ -41,7 +40,7 @@ describe("plan", () => {
     expect(xyMotions(p)).toEqual([
       {from: {x: 0, y: 0}, to: {x: 10, y: 10}, penPos: 0},
       {from: {x: 10, y: 10}, to: {x: 20, y: 10}, penPos: positions.down},
-      {from: {x: 20, y: 10}, to: {x: 0, y: 0}, penPos: positions.zero},
+      {from: {x: 20, y: 10}, to: {x: 0, y: 0}, penPos: positions.up},
     ]);
   });
 
@@ -56,7 +55,7 @@ describe("plan", () => {
       {from: {x: 10, y: 10}, to: {x: 20, y: 10}, penPos: positions.down},
       {from: {x: 20, y: 10}, to: {x: 10, y: 20}, penPos: positions.up},
       {from: {x: 10, y: 20}, to: {x: 20, y: 20}, penPos: positions.down},
-      {from: {x: 20, y: 20}, to: {x: 0, y: 0}, penPos: positions.zero},
+      {from: {x: 20, y: 20}, to: {x: 0, y: 0}, penPos: positions.up},
     ]);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { Vec2 } from "./vec";
 import { formatDuration } from "./util";
 import { Device, PlanOptions, defaultPlanOptions } from "./planning";
 import { PaperSize } from "./paper-size";
+import { Hardware } from "./ebb";
 
 function parseSvg(svg: string) {
   const window = new Window
@@ -16,49 +17,19 @@ function parseSvg(svg: string) {
 }
 
 export function cli(argv: string[]): void {
-  yargs.strict()
-    .option("device", {
-      alias: "d",
-      describe: "device to connect to",
-      type: "string"
+  yargs
+    .strict()
+    .option('hardware', {
+      describe: 'select hardware type',
+      choices: ['v3', 'brushless'] as const,
+      default: 'v3',
+      coerce: value => value as Hardware
     })
-    .command('$0', 'run the saxi web server',
-      yargs => yargs
-        .option("port", {
-          alias: "p",
-          default: Number(process.env.PORT || 9080),
-          describe: "TCP port on which to listen",
-          type: "number"
-        })
-        .option("enable-cors", {
-          describe: "enable cross-origin resource sharing (CORS)",
-          type: "boolean"
-        })
-        .option("max-payload-size", {
-          describe: "maximum payload size to accept",
-          default: "200 mb",
-          type: "string"
-        })
-        .option("firmware-version", {
-          describe: "print the device's firmware version and exit",
-          type: "boolean"
-        }),
-      args => {
-        if (args["firmware-version"]) {
-          connectEBB(args.device).then(async (ebb) => {
-            if (!ebb) {
-              console.error(`No EBB connected`);
-              return process.exit(1);
-            }
-            const fwv = await ebb.firmwareVersion();
-            console.log(fwv);
-            await ebb.close();
-          });
-        } else {
-          startServer(args.port, args.device, args["enable-cors"], args["max-payload-size"]);
-        }
-      }
-    )
+    .option('device', {
+      alias: 'd',
+      describe: 'device to connect to',
+      type: 'string'
+    })
     .command('plot <file>', 'plot an svg, then exit',
       yargs => yargs
         .positional("file", {
@@ -205,6 +176,7 @@ export function cli(argv: string[]): void {
         const planOptions: PlanOptions = {
           paperSize,
           marginMm: args.margin,
+          hardware: args.hardware,
 
           selectedGroupLayers: new Set([]), // TODO
           selectedStrokeLayers: new Set([]), // TODO
@@ -234,7 +206,7 @@ export function cli(argv: string[]): void {
         const p = replan(linesToVecs(lines), planOptions)
         console.log(`${p.motions.length} motions, estimated duration: ${formatDuration(p.duration())}`)
         console.log("connecting to plotter...")
-        const ebb = await connectEBB(args.device)
+        const ebb = await connectEBB(args.hardware, args.device)
         if (!ebb) {
           console.error("Couldn't connect to device!")
           process.exit(1)
@@ -251,17 +223,39 @@ export function cli(argv: string[]): void {
       .check(args => args.percent >= 0 && args.percent <= 100),
     async args => {
       console.log('connecting to plotter...')
-      const ebb = await connectEBB(args.device)
+      const ebb = await connectEBB(args.hardware, args.device)
       if (!ebb) {
         console.error("Couldn't connect to device!")
         process.exit(1)
       }
-      await ebb.setPenHeight(Device.Axidraw.penPctToPos(args.percent), 1000)
+      const device = Device(ebb.hardware)
+      await ebb.setPenHeight(device.penPctToPos(args.percent), 1000)
 
       console.log(`moving to ${args.percent}%...`)
       await ebb.close()
     })
-    .parse(argv);
+    .command('$0', 'run the saxi web server',
+      args => args
+        .option('port', {
+          alias: 'p',
+          describe: 'TCP port on which to listen',
+          default: 9080,
+          type: 'number',
+        })
+        .option('enable-cors', {
+          describe: 'enable cross-origin resource sharing (CORS)',
+          default: false,
+          type: 'boolean',
+        })
+        .option('max-payload-size', {
+          describe: 'maximum payload size to accept',
+          default: '200mb',
+        }),
+      args => {
+        startServer(args.port, args.hardware, args.device, args['enable-cors'], args['max-payload-size'])
+      }
+    )
+    .parse(argv)
 }
 
 function linesToVecs(lines: any[]): Vec2[][] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -170,7 +170,8 @@ export async function startServer (port: number, hardware: Hardware = 'v3', com:
     },
     async postCancel(): Promise<void> {
       const device = Device(ebb.hardware)
-      await ebb.setPenHeight(device.penPctToPos(0), 1000);
+      // TODO: switch to pen up position
+      await ebb.setPenHeight(device.penPctToPos(50), 1000);
     },
     async postPlot(): Promise<void> {
       await ebb.waitUntilMotorsIdle();

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,17 +7,23 @@ import { PortInfo } from "@serialport/bindings-interface"
 import { WakeLock } from "wake-lock";
 import WebSocket from "ws";
 import { SerialPortSerialPort } from "./serialport-serialport";
-import { EBB } from "./ebb";
 import { Device, PenMotion, Motion, Plan } from "./planning";
 import { formatDuration } from "./util";
 import { autoDetect } from '@serialport/bindings-cpp';
-import * as self from './server'  // for mocking
+import * as _self from './server'  // use self-import for test mocking
 
-export function startServer(port: number, device: string | null = null, enableCors = false, maxPayloadSize = "200mb"): Promise<http.Server> {
-  const app = express();
+import { EBB, Hardware } from './ebb'
 
-  app.use("/", express.static(path.join(__dirname, "..", "ui")));
-  app.use(express.json({limit: maxPayloadSize}));
+type Com = string
+
+const getDeviceInfo = (ebb: EBB | null, com: Com) => {
+  return { com: ebb ? com : null, hardware: ebb?.hardware }
+}
+
+export async function startServer (port: number, hardware: Hardware = 'v3', com: Com = null, enableCors = false, maxPayloadSize = '200mb') {
+  const app = express()
+  app.use('/', express.static(path.join(__dirname, '..', 'ui')))
+  app.use(express.json({ limit: maxPayloadSize }))
   if (enableCors) {
     app.use(cors());
   }
@@ -58,7 +64,8 @@ export function startServer(port: number, device: string | null = null, enableCo
       }
     });
 
-    ws.send(JSON.stringify({c: "dev", p: {path: ebb ? /*ebb.port.path*/"/dev/XXX" : null}}));
+    ws.send(JSON.stringify({c: 'dev', p: getDeviceInfo(ebb, com)}))
+
     ws.send(JSON.stringify({c: "pause", p: {paused: !!unpaused}}));
     if (motionIdx != null) {
       ws.send(JSON.stringify({c: "progress", p: {motionIdx}}));
@@ -162,7 +169,8 @@ export function startServer(port: number, device: string | null = null, enableCo
       await ebb.executeMotion(motion);
     },
     async postCancel(): Promise<void> {
-      await ebb.setPenHeight(Device.Axidraw.penPctToPos(0), 1000);
+      const device = Device(ebb.hardware)
+      await ebb.setPenHeight(device.penPctToPos(0), 1000);
     },
     async postPlot(): Promise<void> {
       await ebb.waitUntilMotorsIdle();
@@ -224,10 +232,11 @@ export function startServer(port: number, device: string | null = null, enableCo
 
   return new Promise<http.Server>((resolve) => {
     server.listen(port, () => {
-      async function connect() {
-        for await (const d of ebbs(device)) {
-          ebb = d;
-          broadcast({c: "dev", p: {path: ebb ? /*ebb.port.path*/"/dev/XXX" : null}});
+      async function connect () {
+        const devices = ebbs(com, hardware)
+        for await (const device of devices) {
+          ebb = device
+          broadcast({ c: 'dev', p: getDeviceInfo(ebb, com) })
         }
       }
       connect();
@@ -239,9 +248,9 @@ export function startServer(port: number, device: string | null = null, enableCo
   });
 }
 
-async function tryOpen(path: string): Promise<SerialPort> {
-  const port = new SerialPortSerialPort(path);
-  await port.open({baudRate: 9600})
+async function tryOpen (com: Com) {
+  const port = new SerialPortSerialPort(com)
+  await port.open({ baudRate: 9600 })
   return port
 }
 
@@ -259,8 +268,8 @@ async function listEBBs() {
   return ports.filter(isEBB).map((p: { path: any; }) => p.path);
 }
 
-export async function waitForEbb() {
-  // eslint-disable-next-line no-constant-condition
+export async function waitForEbb (): Promise<Com> {
+// eslint-disable-next-line no-constant-condition
   while (true) {
     const ebbs = await listEBBs();
     if (ebbs.length) {
@@ -270,16 +279,16 @@ export async function waitForEbb() {
   }
 }
 
-async function* ebbs(path?: string) {
+async function * ebbs (path?: string, hardware: Hardware = 'v3') {
   while (true) {
     try {
-      const com = path || (await self.waitForEbb());  // use self-import for mocking
-      console.log(`Found EBB at ${com}`);
-      const port = await tryOpen(com);
+      const com: Com = path || (await _self.waitForEbb()) // use self-import for test mocking
+      console.log(`Found EBB at ${com}`)
+      const port = await tryOpen(com)
       const closed = new Promise((resolve) => {
         port.addEventListener('disconnect', resolve, { once: true })
       });
-      yield new EBB(port);
+      yield new EBB(port, hardware);
       await closed;
       yield null;
       console.error(`Lost connection to EBB, reconnecting...`);
@@ -291,17 +300,13 @@ async function* ebbs(path?: string) {
   }
 }
 
-export async function connectEBB(path: string | undefined): Promise<EBB | null> {
-  if (path) {
-    const port = await tryOpen(path);
-    return new EBB(port);
-  } else {
-    const ebbs = await listEBBs();
-    if (ebbs.length) {
-      const port = await tryOpen(ebbs[0]);
-      return new EBB(port);
-    } else {
-      return null;
-    }
+export async function connectEBB (hardware: Hardware = 'v3', device: string | undefined): Promise<EBB | null> {
+  if (!device) {
+    const ebbs = await listEBBs()
+    if (ebbs.length === 0) return null
+    device = ebbs[0]
   }
+
+  const port = await tryOpen(device)
+  return new EBB(port, hardware)
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -179,7 +179,12 @@ class WebSerialDriver implements Driver {
 
     if (this._cancelRequested) {
       const device = Device(this.ebb.hardware);
-      await this.ebb.setPenHeight(device.penPctToPos(0), 1000);
+      if (!penIsUp) {
+        // Move to the pen up position, or 50% if no position was found
+        const penMotion = plan.motions.find((motion): motion is PenMotion => motion instanceof PenMotion)
+        const penUpPosition = penMotion ? Math.max(penMotion.initialPos, penMotion.finalPos) :  device.penPctToPos(50)
+        await this.ebb.setPenHeight(penUpPosition, 1000);
+      }
       if (this.oncancelled) this.oncancelled()
     } else {
       if (this.onfinished) this.onfinished()


### PR DESCRIPTION
Supercedes https://github.com/alexrudd2/saxi/pull/94.  Closes https://github.com/nornagon/saxi/issues/136

@jedahan's code adds support for the brushless servo upgrade, which uses a different pinout on the EBB.

The hardware can be selected with a new CLI option:
* `--hardware v3` is the default brushed motor
* `--hardware brushless` is the brushless servo.

This can also be selected with a checkbox in the GUI.
<img width="183" alt="Screenshot 2023-10-16 at 10 43 21 AM" src="https://github.com/alexrudd2/saxi/assets/52292902/5e50ca2e-15f7-43ff-a1eb-0307dc8d8f40">
