### PR TITLE
Simplify startup scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "prepare": "rimraf dist && npm run build",
     "prestart": "npm run build",
     "start": "node cli.js",
-    "serve": "npm run build:server && npm start",
-    "dev": "npm run serve & BUILD_MODE=development npm run build:ui",
+    "dev": "BUILD_MODE=development npm start",
     "deploy": "rimraf dist/ui && IS_WEB=1 npm run build:ui && gh-pages --dist dist/ui",
     "test": "jest"
   },


### PR DESCRIPTION
Currently the build steps run twice in some cases, notably using `npm run dev`. This is because the `prestart` script runs before `start` automatically, `prebuild` runs before `build`, and so on.

After removing the redundant build steps, there's no difference between `npm run serve` and `npm run start`, so remove that as well.﻿
