### PR TITLE
Make wakelock optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "optimize-paths": "^1.2.2",
         "serialport": "^12.0.0 || ^13.0.0",
         "svgdom": "0.1.16",
-        "wake-lock": "^0.2.0",
         "web-streams-polyfill": "^4.0.0",
         "ws": "^8.0.0",
         "yargs": "^17.0.0"
@@ -59,7 +58,8 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@esbuild/linux-arm": "^0.19.2 || ^0.20.0 || ^0.24.0"
+        "@esbuild/linux-arm": "^0.19.2 || ^0.20.0 || ^0.24.0",
+        "wake-lock": "^0.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2868,7 +2868,10 @@
     },
     "node_modules/bindings": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4209,7 +4212,10 @@
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/filename-reserved-regex": {
       "version": "2.0.0",
@@ -8268,7 +8274,11 @@
     },
     "node_modules/wake-lock": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wake-lock/-/wake-lock-0.2.0.tgz",
+      "integrity": "sha512-jQ7T9MHvng8LGGK57eTGvQVdUMXHtAwdv2YUFa7hVAUOH1XvHz6FREe6G7S7gukfogQXje68HLjkvCIEIhkgXg==",
+      "hasInstallScript": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "optimize-paths": "^1.2.2",
     "serialport": "^12.0.0 || ^13.0.0",
     "svgdom": "0.1.16",
-    "wake-lock": "^0.2.0",
     "web-streams-polyfill": "^4.0.0",
     "ws": "^8.0.0",
     "yargs": "^17.0.0"
@@ -87,6 +86,7 @@
     "cli.js"
   ],
   "optionalDependencies": {
-    "@esbuild/linux-arm": "^0.19.2 || ^0.20.0 || ^0.24.0"
+    "@esbuild/linux-arm": "^0.19.2 || ^0.20.0 || ^0.24.0",
+    "wake-lock": "^0.2.0"
   }
 }


### PR DESCRIPTION
`wakelock` only ever worked on MacOS, and tends to cause problems when `node-gyp` tries to install on other platforms.

@drskullster