### PR TITLE
Return carriage to home on cancellation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -172,6 +172,7 @@ export async function startServer (port: number, hardware: Hardware = 'v3', com:
     },
     async postCancel(initialPenHeight: number): Promise<void> {
       await ebb.setPenHeight(initialPenHeight, 1000);
+      await ebb.query('HM,4000'); // HM returns carriage home without 3rd and 4th arguments
     },
     async postPlot(): Promise<void> {
       await ebb.waitUntilMotorsIdle();

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -184,6 +184,7 @@ class WebSerialDriver implements Driver {
         const penMotion = plan.motions.find((motion): motion is PenMotion => motion instanceof PenMotion);
         const penUpPosition = penMotion ? Math.max(penMotion.initialPos, penMotion.finalPos) :  device.penPctToPos(50);
         await this.ebb.setPenHeight(penUpPosition, 1000);
+        await this.ebb.query('HM,4000'); // HM returns carriage home without 3rd and 4th arguments
       }
       if (this.oncancelled) this.oncancelled();
     } else {


### PR DESCRIPTION
This one might need a discussion: for me it makes sense to return home after cancellation, and it's actually the only way to save a plot if for example you realize that you started with the wrong pen.

But this is a specific use case, maybe there are others that I didn't consider where homing wouldn't be ideal?