### PR TITLE
Change default microstepping resolution to 16x instead of 8x

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -164,7 +164,7 @@ export async function startServer (port: number, hardware: Hardware = 'v3', com:
 
   const realPlotter: Plotter = {
     async prePlot(initialPenHeight: number): Promise<void> {
-      await ebb.enableMotors(2);
+      await ebb.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
       await ebb.setPenHeight(initialPenHeight, 1000, 1000);
     },
     async executeMotion(motion: Motion, _progress: [number, number]): Promise<void> {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -156,7 +156,7 @@ class WebSerialDriver implements Driver {
   }
 
   public async plot(plan: Plan): Promise<void> {
-    const microsteppingMode = 2;
+    const microsteppingMode = 1; // 16x microstepping, matches defaults from Axidraw
     this._unpaused = null;
     this._cancelRequested = false;
     await this.ebb.enableMotors(microsteppingMode);


### PR DESCRIPTION
This increases the accuracy at the cost of lowering the speed a little, and fixes inaccuracy issues on non Axidraw machines like the iDraw H/SE.

Closes #173 