### PR TITLE
Switch to ESM and ECMA2022

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
   ],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
   root: true,

--- a/build.mjs
+++ b/build.mjs
@@ -6,7 +6,7 @@ const buildOptions = {
   entryPoints: ['src/ui.tsx'],
   bundle: true,
   platform: 'browser',
-  target: 'es2020',
+  target: 'es2022',
   minify: true,
   sourcemap: true,
   metafile: true,
@@ -27,7 +27,7 @@ const buildOptions = {
       }]
     })
   ],
-  resolveExtensions: ['.js', '.ts', '.tsx', '.svg', '.worker.js'],
+  resolveExtensions: ['.mjs', '.js', '.ts', '.tsx', '.svg', '.worker.js'],
 };
 
 (async () => {

--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('./dist/server/cli').cli()

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { cli } from './dist/server/cli.js';
+cli();

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-module.exports = {
-  server: require('./dist/server/server'),
-}

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,2 @@
+import server from './dist/server/server.js';
+export { server };

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "hardware",
     "robot"
   ],
-  "main": "index.js",
+  "main": "index.mjs",
   "bin": {
-    "saxi": "cli.js"
+    "saxi": "cli.mjs"
   },
   "scripts": {
     "prebuild": "npm run lint",
@@ -25,7 +25,7 @@
     "build:server": "tsc",
     "build:ui": "node --experimental-modules build.mjs",
     "prepare": "rimraf dist && npm run build",
-    "start": "npm run build && node cli.js",
+    "start": "npm run build && node cli.mjs",
     "dev": "BUILD_MODE=development npm start",
     "deploy": "rimraf dist/ui && IS_WEB=1 npm run build:ui && gh-pages --dist dist/ui",
     "test": "jest"
@@ -79,12 +79,13 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "type": "module",
   "jest": {
     "preset": "ts-jest"
   },
   "files": [
     "/dist",
-    "cli.js"
+    "cli.mjs"
   ],
   "optionalDependencies": {
     "@esbuild/linux-arm": "^0.25.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2022",
     "esModuleInterop": true,
-    "target": "es6",
+    "target": "ES2022",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "module": "es6",
-    "target": "es6",
+    "module": "es2022",
+    "target": "es2022",
     "moduleResolution": "node",
     "jsx": "react",
     "allowJs": true


### PR DESCRIPTION
https://github.com/alexrudd2/saxi/pull/106 sometimes fails to work for me, and I think the real reason is because it's expecting ESM.

Switching over to ECMA across the board seems to help.  `esbuild` has already been using it for a while, so the switch seems safe.