### PR TITLE
Migrate to ESM and ECMA2022 (second attempt)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
   ],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
   root: true,

--- a/build.mjs
+++ b/build.mjs
@@ -6,7 +6,7 @@ const buildOptions = {
   entryPoints: ['src/ui.tsx'],
   bundle: true,
   platform: 'browser',
-  target: 'es2020',
+  target: 'es2022',
   minify: true,
   sourcemap: true,
   metafile: true,
@@ -27,7 +27,7 @@ const buildOptions = {
       }]
     })
   ],
-  resolveExtensions: ['.js', '.ts', '.tsx', '.svg', '.worker.js'],
+  resolveExtensions: ['.mjs', '.js', '.ts', '.tsx', '.svg', '.worker.js'],
 };
 
 (async () => {

--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('./dist/server/cli').cli()

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { cli } from './dist/server/cli.js';
+cli();

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-module.exports = {
-  server: require('./dist/server/server'),
-}

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,2 @@
+import server from './dist/server/server.js';
+export { server };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  moduleNameMapper: {
+    './ebb.js': './ebb.ts',
+    './massager.js': './massager.ts',
+    './paper-size.js': './paper-size.ts',
+    './planning.js': './planning.ts',
+    './regex-transform-stream.js': './regex-transform-stream.ts',
+    './serialport-serialport.js': './serialport-serialport.ts',
+    './server.js': './server.ts',
+    './util.js': './util.ts',
+    './vec.js': './vec.ts',
+  },
+};

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   moduleNameMapper: {
     './ebb.js': './ebb.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "yargs": "^17.0.0"
       },
       "bin": {
-        "saxi": "cli.js"
+        "saxi": "cli.mjs"
       },
       "devDependencies": {
         "@craftamap/esbuild-plugin-html": "^0.7.0 || ^0.8.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "hardware",
     "robot"
   ],
-  "main": "index.js",
+  "main": "index.mjs",
   "bin": {
-    "saxi": "cli.js"
+    "saxi": "cli.mjs"
   },
   "scripts": {
     "prebuild": "npm run lint",
@@ -25,7 +25,7 @@
     "build:server": "tsc",
     "build:ui": "node --experimental-modules build.mjs",
     "prepare": "rimraf dist && npm run build",
-    "start": "npm run build && node cli.js",
+    "start": "npm run build && node cli.mjs",
     "dev": "BUILD_MODE=development npm start",
     "deploy": "rimraf dist/ui && IS_WEB=1 npm run build:ui && gh-pages --dist dist/ui",
     "test": "jest"
@@ -79,12 +79,13 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "type": "module",
   "jest": {
     "preset": "ts-jest"
   },
   "files": [
     "/dist",
-    "cli.js"
+    "cli.mjs"
   ],
   "optionalDependencies": {
     "@esbuild/linux-arm": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -80,9 +80,6 @@
     "node": ">=18.0.0"
   },
   "type": "module",
-  "jest": {
-    "preset": "ts-jest"
-  },
   "files": [
     "/dist",
     "cli.mjs"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,15 +1,15 @@
 import yargs from "yargs";
 import { hideBin } from 'yargs/helpers';
-import { connectEBB, startServer } from "./server";
-import { replan } from "./massager";
+import { connectEBB, startServer } from "./server.js";
+import { replan } from "./massager.js";
 import { Window } from "svgdom";
 import { readFileSync } from "node:fs";
 import { flattenSVG, type Line } from "flatten-svg";
-import type { Vec2 } from "./vec";
-import { formatDuration } from "./util";
-import { Device, type PlanOptions, defaultPlanOptions } from "./planning";
-import { PaperSize } from "./paper-size";
-import type { Hardware } from "./ebb";
+import type { Vec2 } from "./vec.js";
+import { formatDuration } from "./util.js";
+import { Device, type PlanOptions, defaultPlanOptions } from "./planning.js";
+import { PaperSize } from "./paper-size.js";
+import type { Hardware } from "./ebb.js";
 
 function parseSvg(svg: string) {
   const window = new Window;

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -1,6 +1,6 @@
-import { type Block, type Motion, PenMotion, type Plan, XYMotion } from "./planning";
-import { RegexParser } from "./regex-transform-stream";
-import { type Vec2, vsub } from "./vec";
+import { type Block, type Motion, PenMotion, type Plan, XYMotion } from "./planning.js";
+import { RegexParser } from "./regex-transform-stream.js";
+import { type Vec2, vsub } from "./vec.js";
 
 /** Split d into its fractional and integral parts */
 function modf(d: number): [number, number] {

--- a/src/massager.ts
+++ b/src/massager.ts
@@ -1,7 +1,7 @@
 import { reorder as sortPaths, elideShorterThan, merge as joinNearbyPaths } from "optimize-paths";
-import { Device, type Plan, type PlanOptions, plan } from "./planning";
-import { dedupPoints, scaleToPaper, cropToMargins } from "./util";
-import { type Vec2, vmul, vrot } from "./vec";
+import { Device, type Plan, type PlanOptions, plan } from "./planning.js";
+import { dedupPoints, scaleToPaper, cropToMargins } from "./util.js";
+import { type Vec2, vmul, vrot } from "./vec.js";
 
 // CSS, and thus SVG, defines 1px = 1/96th of 1in
 // https://www.w3.org/TR/css-values-4/#absolute-lengths

--- a/src/paper-size.ts
+++ b/src/paper-size.ts
@@ -1,4 +1,4 @@
-import { type Vec2, vmul } from "./vec";
+import { type Vec2, vmul } from "./vec.js";
 
 function vround(v: Vec2, digits = 2): Vec2 {
   return { x: Number(v.x.toFixed(digits)), y: Number(v.y.toFixed(digits)) };

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -1,7 +1,7 @@
 // Cribbed from https://github.com/fogleman/axi/blob/master/axi/planner.py
-import type { Hardware } from './ebb';
-import { PaperSize } from './paper-size';
-import { vadd, vdot, type Vec2, vlen, vmul, vnorm, vsub } from './vec';
+import type { Hardware } from './ebb.js';
+import { PaperSize } from './paper-size.js';
+import { vadd, vdot, type Vec2, vlen, vmul, vnorm, vsub } from './vec.js';
 const epsilon = 1e-9;
 
 export interface PlanOptions {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,13 +9,12 @@ import type { PortInfo } from "@serialport/bindings-interface";
 import { WakeLock } from "wake-lock";
 import type WebSocket from 'ws';
 import { WebSocketServer } from 'ws';
-import { SerialPortSerialPort } from "./serialport-serialport";
-import { PenMotion, type Motion, Plan } from "./planning";
-import { formatDuration } from "./util";
+import { SerialPortSerialPort } from "./serialport-serialport.js";
+import { PenMotion, type Motion, Plan } from "./planning.js";
+import { formatDuration } from "./util.js";
 import { autoDetect } from '@serialport/bindings-cpp';
-import * as _self from './server';  // use self-import for test mocking
-
-import { EBB, type Hardware } from './ebb';
+import * as _self from './server.js';  // use self-import for test mocking
+import { EBB, type Hardware } from './ebb.js';
 
 type Com = string
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,8 +14,6 @@ import { formatDuration } from "./util.js";
 import { autoDetect } from '@serialport/bindings-cpp';
 import * as _self from './server.js';  // use self-import for test mocking
 import { EBB, type Hardware } from './ebb.js';
-import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
 import path from 'node:path';
 
 type Com = string
@@ -26,8 +24,7 @@ const getDeviceInfo = (ebb: EBB | null, com: Com) => {
 
 export async function startServer (port: number, hardware: Hardware = 'v3', com: Com = null, enableCors = false, maxPayloadSize = '200mb') {
   const app = express();
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  app.use('/', express.static(path.join(__dirname, '..', 'ui')));
+  app.use('/', express.static(path.join(path.resolve(), 'dist', 'ui')));
   app.use(express.json({ limit: maxPayloadSize }));
   if (enableCors) {
     app.use(cors());

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,6 @@ import type { Response, Request } from "express";
 import express from "express";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import path from "node:path";
 import type { PortInfo } from "@serialport/bindings-interface";
 import { WakeLock } from "wake-lock";
 import type WebSocket from 'ws';
@@ -15,6 +14,9 @@ import { formatDuration } from "./util.js";
 import { autoDetect } from '@serialport/bindings-cpp';
 import * as _self from './server.js';  // use self-import for test mocking
 import { EBB, type Hardware } from './ebb.js';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import path from 'node:path';
 
 type Com = string
 
@@ -24,6 +26,7 @@ const getDeviceInfo = (ebb: EBB | null, com: Com) => {
 
 export async function startServer (port: number, hardware: Hardware = 'v3', com: Com = null, enableCors = false, maxPayloadSize = '200mb') {
   const app = express();
+  const __dirname = dirname(fileURLToPath(import.meta.url));
   app.use('/', express.static(path.join(__dirname, '..', 'ui')));
   app.use(express.json({ limit: maxPayloadSize }));
   if (enableCors) {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -6,11 +6,11 @@ import colormap from "colormap";
 
 import { flattenSVG } from "flatten-svg";
 import { PaperSize } from "./paper-size";
-import { Device, Plan, type PlanOptions, defaultPlanOptions, XYMotion, PenMotion } from "./planning";
-import { formatDuration } from "./util";
-import type { Vec2 } from "./vec";
+import { Device, Plan, type PlanOptions, defaultPlanOptions, XYMotion, PenMotion } from "./planning.js";
+import { formatDuration } from "./util.js";
+import type { Vec2 } from "./vec.js";
 
-import PlanWorker from "./plan.worker";
+import PlanWorker from "./plan.worker.js";
 
 import "./style.css";
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
-import type { PaperSize } from "./paper-size";
-import { vadd, type Vec2, vlen2, vmul, vsub } from "./vec";
+import type { PaperSize } from "./paper-size.js";
+import { vadd, type Vec2, vlen2, vmul, vsub } from "./vec.js";
 
 /** Format a smallish duration in 2h30m15s form */
 export function formatDuration(seconds: number): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2022",
     "esModuleInterop": true,
-    "target": "es6",
+    "target": "ES2022",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "module": "es6",
-    "target": "es6",
+    "module": "es2022",
+    "target": "es2022",
     "moduleResolution": "node",
     "jsx": "react",
     "allowJs": true


### PR DESCRIPTION
Closes #179

Better attempt at https://github.com/alexrudd2/saxi/pull/178 which had to be reverted.

`npm run dev`, `npm run start`, and `npm run dev` all work for me, but I didn't try with `IS_WEB`