### PR TITLE
:broom: remove plan.worker.js

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -3,7 +3,7 @@ import inlineWorker from 'esbuild-plugin-inline-worker';
 import { htmlPlugin as html } from '@craftamap/esbuild-plugin-html';
 
 const buildOptions = {
-  entryPoints: ['src/ui.tsx'],
+  entryPoints: ['src/ui.tsx', 'src/background-planner.ts'],
   bundle: true,
   platform: 'browser',
   target: 'es2022',

--- a/src/background-planner.ts
+++ b/src/background-planner.ts
@@ -9,6 +9,4 @@ self.addEventListener("message", (m) => {
   self.postMessage(serialized);
 });
 
-export default {} as typeof Worker & {
-  new(): Worker;
-};
+export {};

--- a/src/plan.worker.js
+++ b/src/plan.worker.js
@@ -1,1 +1,0 @@
-require("./background-planner");

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -10,8 +10,6 @@ import { Device, Plan, type PlanOptions, defaultPlanOptions, XYMotion, PenMotion
 import { formatDuration } from "./util.js";
 import type { Vec2 } from "./vec.js";
 
-import PlanWorker from "./plan.worker.js";
-
 import "./style.css";
 
 import pathJoinRadiusIcon from "./icons/path-joining radius.svg";
@@ -399,7 +397,7 @@ const usePlan = (paths: Vec2[][] | null, planOptions: PlanOptions) => {
       }
     }
     lastPaths.current = paths;
-    const worker = new (PlanWorker as any)();
+    const worker = new Worker('background-planner.js');
     setIsPlanning(true);
     console.time("posting to worker");
     worker.postMessage({ paths, planOptions });


### PR DESCRIPTION
It seemed dumb to me having an intermediate JavaScript just to load another file, until I started to read how the [Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Worker) works.
I'm trying to simplify it, but the code needs to be transpiled so it can be run on a Worker...