### PR TITLE
Kill webstreams-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "optimize-paths": "^1.2.2",
         "serialport": "^12.0.0 || ^13.0.0",
         "svgdom": "0.1.20",
-        "web-streams-polyfill": "^4.0.0",
         "ws": "^8.0.0",
         "yargs": "^17.0.0"
       },
@@ -8816,14 +8815,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0.tgz",
-      "integrity": "sha512-0zJXHRAYEjM2tUfZ2DiSOHAa2aw1tisnnhU3ufD57R8iefL+DcdJyRBRyJpG+NUimDgbTI/lH+gAE1PAvV3Cgw==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "optimize-paths": "^1.2.2",
     "serialport": "^12.0.0 || ^13.0.0",
     "svgdom": "0.1.20",
-    "web-streams-polyfill": "^4.0.0",
     "ws": "^8.0.0",
     "yargs": "^17.0.0"
   },

--- a/src/regex-transform-stream.ts
+++ b/src/regex-transform-stream.ts
@@ -1,4 +1,3 @@
-import "web-streams-polyfill/polyfill";
 export class RegexParser extends TransformStream {
   public constructor(opts: { regex: RegExp }) {
     if (opts.regex === undefined) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,4 @@
 import cors from "cors";
-import "web-streams-polyfill/polyfill";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from 'node:path';


### PR DESCRIPTION
WebStreams are stable as of Node 18 (https://nodejs.org/api/webstreams.html#web-streams-api), so there's no need to polyfill.
