### PR TITLE
Fix v3/brushless indication

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -501,7 +501,7 @@ function PenHeight({ state, driver }: { state: State; driver: Driver }) {
 function HardwareOptions({ state }: { state: State }) {
   return <div>
     <div title="Motor type (affects pin and power settings)">
-      motor: {state.planOptions.hardware}
+      motor: {state.deviceInfo?.hardware}
     </div>
   </div>;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1210,6 +1210,7 @@ function Root() {
     };
     driver.ondevinfo = (devInfo: DeviceInfo) => {
       dispatch({ type: "SET_DEVICE_INFO", value: devInfo });
+      dispatch({ type: "SET_PLAN_OPTION", value: { ... state.planOptions, hardware: devInfo.hardware } } );
     };
     driver.onpause = (paused: boolean) => {
       dispatch({ type: "SET_PAUSED", value: paused });


### PR DESCRIPTION
https://github.com/alexrudd2/saxi/pull/158/files was not entirely correct.

![Image](https://github.com/user-attachments/assets/65ea7840-4151-4294-ba22-f73d969b16fc)

There are `state.planOptions.deviceInfo.hardware` and `planOptions.state.hardware` which are not in sync somehow.

This isn't yet a full fix, but at least fixes the display when using a brushless motor.
