### PR TITLE
Don't re-add the same event listeners on every state change

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1202,6 +1202,7 @@ function Root() {
     window.localStorage.setItem("planOptions", JSON.stringify(state.planOptions));
   }, [state.planOptions]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies(setPlan): React setters are stable
   useEffect(() => {
     if (driver == null) return;
     driver.onprogress = (motionIdx: number) => {
@@ -1228,6 +1229,7 @@ function Root() {
     };
   }, [driver]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies(setPlan): React setters are stable
   useEffect(() => {
     const ondrop = (e: DragEvent) => {
       e.preventDefault();
@@ -1270,7 +1272,7 @@ function Root() {
       document.body.removeEventListener("dragleave", ondragleave);
       document.removeEventListener("paste", onpaste);
     };
-  });
+  }, []);
 
   // Each time new motion is started, save the start time
   const currentMotionStartedTime = useMemo(() => {


### PR DESCRIPTION
If `useEffect()` is has no second argument, it will run on every state change.

For the code adding drag-and-drop listeners, this is unnecessary and causes the same listeners to be added 4 times.
![image](https://github.com/user-attachments/assets/191c0a32-ed52-4396-a73d-31e0cc3568db)

Passing an empty array (`[]`) as the second argument means the listeners are only added once.
