### PR TITLE
Drop Node 18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 23.x]
         os: ["windows-latest", "ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/cors": "^2.8.4",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.0.0",
-        "@types/node": "^18.0.0 || ^20.0.0 || ^22.0.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || ^23.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/supertest": "^6.0.2",
@@ -51,7 +51,7 @@
         "typescript": "^5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
         "@esbuild/linux-arm": "^0.25.0",
@@ -2169,13 +2169,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz",
-      "integrity": "sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==",
+      "version": "20.17.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
+      "integrity": "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/qs": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/cors": "^2.8.4",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.0.0",
-    "@types/node": "^18.0.0 || ^20.0.0 || ^22.0.0",
+    "@types/node": "^20.0.0 || ^22.0.0 || ^23.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/supertest": "^6.0.2",
@@ -73,7 +73,7 @@
     "yargs": "^17.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "type": "module",
   "files": [


### PR DESCRIPTION
Node 18 went EOL on Apr 30, 2025.
