### PR TITLE
consolidate Path and Line

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
  * Execute also one-off instructions on the device.
  */
 import { readFileSync } from "node:fs";
-import { type Line, flattenSVG } from "flatten-svg";
+import { flattenSVG } from "flatten-svg";
 import { Window } from "svgdom";
 import yargs from "yargs";
 import { hideBin } from 'yargs/helpers';
@@ -12,7 +12,7 @@ import { replan } from "./massager.js";
 import { PaperSize } from "./paper-size.js";
 import { Device, type PlanOptions, defaultPlanOptions } from "./planning.js";
 import { connectEBB, startServer } from "./server.js";
-import { linesToPaths, formatDuration } from "./util.js";
+import { formatDuration } from "./util.js";
 
 function parseSvg(svg: string) {
   const window = new Window;
@@ -210,7 +210,7 @@ export function cli(argv: string[]): void {
           pathJoinRadius: args["path-join-radius"],
           pointJoinRadius: args["point-join-radius"],
         };
-        const p = replan(linesToPaths(lines), planOptions);
+        const p = replan(lines, planOptions);
         console.log(`${p.motions.length} motions, estimated duration: ${formatDuration(p.duration())}`);
         console.log("connecting to plotter...");
         const ebb = await connectEBB(args.hardware, args.device);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,17 +5,18 @@ declare module 'colormap';
 declare module '*.svg';
 
 // https://github.com/nornagon/flatten-svg/issues/27
+// since we have to define the types anyways, we can rename them
 declare module 'flatten-svg' {
   interface Options {
     maxError: number;
   }
-  type Point = [number, number];
-  interface Line {
-    points: Point[];
-    stroke?: string;
-    groupId?: string;
+  type Vec2 = { x: number, y: number }; // corresponds to Point
+  interface Path { // corresponds to Line
+    points: Vec2[];
+    stroke: string;
+    groupId: string;
   }
-  export function flattenSVG(svg: SVGElement, options?: Partial<Options>): Line[];
+  export function flattenSVG(svg: SVGElement, options?: Partial<Options>): Path[];
 
 }
 

--- a/src/massager.ts
+++ b/src/massager.ts
@@ -1,6 +1,7 @@
+import type { Path } from "flatten-svg";
 import { elideShorterThan, merge as joinNearbyPaths, reorder as sortPaths } from "optimize-paths";
 import { Device, type Plan, type PlanOptions, plan } from "./planning.js";
-import { type Path, cropToMargins, dedupPoints, scaleToPaper } from "./util.js";
+import { cropToMargins, dedupPoints, scaleToPaper } from "./util.js";
 import { type Vec2, vmul, vrot } from "./vec.js";
 
 
@@ -17,7 +18,7 @@ const mmPerSvgUnit = mmPerInch / svgUnitsPerInch;
  * @returns 
  */
 export function replan(inPaths: Path[], planOptions: PlanOptions): Plan {
-  let paths: Vec2[][] = inPaths;
+  let paths: Vec2[][] = inPaths.map(path => path.points);
   const device = Device(planOptions.hardware);
 
   // Rotate drawing around center of paper to handle plotting portrait drawings

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -7,10 +7,10 @@ import colormap from "colormap";
 import React, { type ChangeEvent, Fragment, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, useReducer } from "react";
 import { createRoot } from 'react-dom/client';
 
-import { type Line, flattenSVG } from "flatten-svg";
+import { type Path, flattenSVG } from "flatten-svg";
 import { PaperSize } from "./paper-size";
 import { Device, type MotionData, Plan, type PlanOptions, XYMotion, defaultPlanOptions } from "./planning.js";
-import { type Path, formatDuration, linesToPaths } from "./util.js";
+import { formatDuration } from "./util.js";
 import type { Vec2 } from "./vec.js";
 
 import "./style.css";
@@ -48,7 +48,7 @@ const initialState = {
   plannedOptions: null as PlanOptions | null,
 
   // Info about the currently-loaded SVG.
-  paths: null as Vec2[][] | null,
+  paths: null as Path[] | null,
   groupLayers: [] as string[],
   strokeLayers: [] as string[],
 
@@ -119,7 +119,7 @@ function reducer(state: State, action: Action): State {
 }
 
 
-const usePlan = (paths: Vec2[][] | null, planOptions: PlanOptions) => {
+const usePlan = (paths: Path[] | null, planOptions: PlanOptions) => {
   const [isPlanning, setIsPlanning] = useState(false);
   const [latestPlan, setPlan] = useState<Plan | null>(null);
 
@@ -144,7 +144,7 @@ const usePlan = (paths: Vec2[][] | null, planOptions: PlanOptions) => {
     return null;
   }
 
-  const lastPaths = useRef<Vec2[][]>(null);
+  const lastPaths = useRef<Path[]>(null);
   const lastPlan = useRef<Plan>(null);
   const lastPlanOptions = useRef<PlanOptions>(null);
 
@@ -1160,8 +1160,7 @@ function readSvg(svgString: string): Path[] {
   try {
     div.innerHTML = svgString;
     const svg = div.querySelector("svg") as SVGSVGElement;
-    const lines = flattenSVG(svg);
-    const paths = linesToPaths(lines);
+    const paths = flattenSVG(svg);
     return paths;
   } finally {
     div.remove();

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,30 +1,5 @@
 import type { PaperSize } from "./paper-size.js";
 import { type Vec2, vadd, vlen2, vmul, vsub } from "./vec.js";
-import type { Line } from "flatten-svg";
-
-
-/**
- * An array of Vec2 with stroke and groupId.
- */
-export interface Path extends Array<Vec2> {
-  stroke: string;
-  groupId: string;
-}
-
-
-/**
- * Convert an array of Lines into an array of Path. Use this as a
- * Vec2 matrix to display on a canvas
- */
-export function linesToPaths(lines: Line[]): Path[] {
-  return lines.map(({ points, stroke, groupId }) => {
-    const a = points.map(([x, y]) => ({ x, y })) as Path;
-    a.stroke = stroke;
-    a.groupId = groupId;
-    return a;
-  });
-}
-
 
 /** Format a smallish duration in 2h30m15s form */
 export function formatDuration(seconds: number): string {


### PR DESCRIPTION
See conversations in https://github.com/alexrudd2/saxi/pull/208/

`Path` and `Line` are pretty redundant.  Since the `flatten-svg` package doesn't actually export its types properly (https://github.com/nornagon/flatten-svg/issues/27), we have to redefine them anyways.

This happens in `global.d.ts`.  If we're already redefining them, renaming them (`Point` -> `Vec2` and `Line` -> `Path`) can happen at the same time.  Normally, redefining exported types like this is a terrible idea.  However, the author is the original author of `saxi`, there are no other users, and it's not maintained anyways.
