### PR TITLE
only use the esbuild server for WebSerial

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -34,7 +34,7 @@ const buildOptions = {
 
 (async() => {
   try {
-    if (process.env.BUILD_MODE === 'development') {
+    if (process.env.IS_WEB) {
       // enables live-reloading
       const ctx = await context({
         ...buildOptions,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "rimraf dist && npm run build",
     "start": "npm run build && node cli.mjs",
     "start-svgio": "npm run build && node cli.mjs --svgio-api-key YOUR_API_KEY",
-    "dev": "cross-env BUILD_MODE=development npm start",
+    "start-webserial": "cross-env IS_WEB=1 npm run build:ui",
     "deploy": "rimraf dist/ui && cross-env IS_WEB=1 npm run build:ui && gh-pages --dist dist/ui",
     "test": "jest"
   },

--- a/src/drivers.ts
+++ b/src/drivers.ts
@@ -33,21 +33,6 @@ export abstract class BaseDriver {
   abstract close(): Promise<void>;
 }
 
-export class NullDriver extends BaseDriver {
-  plot(): void {}
-  cancel(): void {}
-  pause(): void {}
-  resume(): void {}
-  setPenHeight(): void {}
-  limp(): void {}
-  name(): string {
-    return "NullDriver";
-  }
-  close(): Promise<void> {
-    return Promise.resolve();
-  }
-}
-
 /**
  * WebSerial driver for the EBB. Implement interface by connecting directly to the Axi 
  * machine. Used on serverless configuration (IS_WEB is set), where the control is handled


### PR DESCRIPTION
Closes #192.

Make it explicit that the `esbuild` hot-reload mode only works with WebSerial.
