### PR TITLE
use `install` not `ci` to utilize cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci --prefer-offline --no-audit
+    - run: npm install --prefer-offline --no-audit  --no-fund
     - run: npm test
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,13 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+    - name: Cache dependencies and build info
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules
+          dist/.tsbuildinfo
+        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
     - run: npm install --prefer-offline --no-audit  --no-fund
     - run: npm test
 permissions:


### PR DESCRIPTION
The attempts to cache the Node install are wasted with `npm ci`