### PR TITLE
Add profile for NextDraw 2234 (and extend hardware configuration)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ export function cli(argv: string[]): void {
     .strict()
     .option('hardware', {
       describe: 'select hardware type',
-      choices: ['v3', 'brushless'] as const,
+      choices: ['v3', 'brushless', 'nextdraw-2234'] as const,
       default: 'v3',
       coerce: value => value as Hardware
     })

--- a/src/drivers.ts
+++ b/src/drivers.ts
@@ -29,6 +29,7 @@ export abstract class BaseDriver {
   abstract resume(): void;
   abstract setPenHeight(height: number, rate: number): void;
   abstract limp(): void;
+  abstract changeHardware(hardware: Hardware): void;
   abstract name(): string;
   abstract close(): Promise<void>;
 }
@@ -165,6 +166,15 @@ export class WebSerialDriver extends BaseDriver {
   public limp(): void {
     this.ebb.disableMotors();
   }
+
+  public changeHardware(hardware: Hardware): void {
+    this.ebb.changeHardware(hardware);
+    this.ondevinfo({
+      path: this._name,
+      hardware: hardware,
+      svgIoEnabled: false // WebSerial doesn't support SVG I/O
+    });
+  }
 }
 
 /**
@@ -279,5 +289,6 @@ export class SaxiDriver extends BaseDriver {
   }
 
   public limp() { this.send({ c: "limp" }); }
+  public changeHardware(hardware: Hardware) { this.send({ c: "changeHardware", p: { hardware } }); }
   public ping() { this.send({ c: "ping" }); }
 }

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -8,7 +8,7 @@ function modf(d: number): [number, number] {
   return [fracPart, intPart];
 }
 
-export type Hardware = 'v3' | 'brushless'
+export type Hardware = 'v3' | 'brushless' | 'nextdraw-2234'
 
 type CommandGenerator<TReturn = unknown> = Iterator<unknown, TReturn, string> & {
   resolve: (value: TReturn) => void;

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -96,6 +96,7 @@ interface ToolingProfile {
 
 export const Device = (hardware = 'v3'): Device => {
   if (hardware === 'brushless') return AxidrawBrushless;
+  if (hardware === 'nextdraw-2234') return NextDraw2234;
   return Axidraw;
 };
 
@@ -134,6 +135,19 @@ const AxidrawBrushless: Device = {
   }
 };
 
+// NextDraw 2234 with brushless motor that requires 70%+ values
+const NextDraw2234: Device = {
+  stepsPerMm: 5,
+
+  penServoMin: 19600, // pen down - 70% of range
+  penServoMax: 28000, // pen up - full range
+
+  penPctToPos(pct: number): number {
+    const t = pct / 100.0;
+    return Math.round(this.penServoMin * t + this.penServoMax * (1 - t));
+  }
+};
+
 export const AxidrawFast: ToolingProfile = {
   penDownProfile: {
     acceleration: 200 * Axidraw.stepsPerMm,
@@ -164,6 +178,23 @@ export const AxidrawBrushlessFast: ToolingProfile = {
   },
   penUpPos: AxidrawBrushless.penPctToPos(50),
   penDownPos: AxidrawBrushless.penPctToPos(60),
+  penDropDuration: 0.08,
+  penLiftDuration: 0.08
+};
+
+export const NextDraw2234Fast: ToolingProfile = {
+  penDownProfile: {
+    acceleration: 200 * NextDraw2234.stepsPerMm,
+    maximumVelocity: 50 * NextDraw2234.stepsPerMm,
+    corneringFactor: 0.127 * NextDraw2234.stepsPerMm
+  },
+  penUpProfile: {
+    acceleration: 400 * NextDraw2234.stepsPerMm,
+    maximumVelocity: 200 * NextDraw2234.stepsPerMm,
+    corneringFactor: 0
+  },
+  penUpPos: NextDraw2234.penPctToPos(50),
+  penDownPos: NextDraw2234.penPctToPos(60),
   penDropDuration: 0.08,
   penLiftDuration: 0.08
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -221,16 +221,6 @@ export async function startServer(port: number, hardware: Hardware = 'v3', com: 
     }
   });
 
-  app.post("/change-hardware", (_req, res) => {
-    if (ebb?.hardware === 'brushless') {
-      ebb.hardware = 'v3';
-    } else if (ebb?.hardware === 'v3') {
-      ebb.hardware = 'brushless';
-    }
-    broadcast({ c: 'dev', p: getDeviceInfo(ebb, com) });
-    // fixme: change planning.ts : Device
-    res.status(200).end();
-  });
 
   function broadcast(msg: Record<string, unknown>) {
     for (const client of clients) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,6 +85,10 @@ export async function startServer(port: number, hardware: Hardware = 'v3', com: 
             })();
           }
           break;
+        case "changeHardware":
+          ebb?.changeHardware(msg.p.hardware);
+          broadcast({ c: 'dev', p: getDeviceInfo(ebb, com) });
+          break;
       }
     });
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -262,6 +262,7 @@ function HardwareOptions({ state, driver }: { state: State, driver: BaseDriver |
       >
         <option value="v3">AxiDraw V3</option>
         <option value="brushless">AxiDraw V3 Brushless</option>
+        <option value="nextdraw-2234">NextDraw 2234</option>
       </select>
     </label>
   </div>;

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -238,17 +238,31 @@ function PenHeight({ state, driver }: { state: State; driver: BaseDriver }) {
   </Fragment>;
 }
 
-function HardwareOptions({ state }: { state: State }) {
+function HardwareOptions({ state, driver }: { state: State, driver: BaseDriver | null }) {
+  const dispatch = useContext(DispatchContext);
+  
+  const handleHardwareChange = (hardware: Hardware) => {
+    // Always update the UI state first
+    dispatch({ type: "SET_PLAN_OPTION", value: { hardware } });
+    
+    // Then notify the driver if connected
+    driver?.changeHardware(hardware);
+  };
+
+  const currentHardware = state.deviceInfo?.hardware || state.planOptions.hardware;
+
   return <div>
-    <label className="flex-checkbox" title="Motor type (affects pin and power settings)">
-      <input
-        type="checkbox"
-        checked={state.deviceInfo?.hardware === 'brushless'}
-        onChange={() => {
-          fetch("/change-hardware", { method: "POST" });
-        }}
-      />
-      brushless
+    <label title="Hardware model (affects servo and motor settings)">
+      Hardware:
+      <select
+        value={currentHardware}
+        onChange={(e) => handleHardwareChange(e.target.value as Hardware)}
+        style={{ marginLeft: '8px' }}
+        disabled={!driver}
+      >
+        <option value="v3">AxiDraw V3</option>
+        <option value="brushless">AxiDraw V3 Brushless</option>
+      </select>
     </label>
   </div>;
 }
@@ -1089,12 +1103,12 @@ function Root() {
               : 'disconnected'}
           </div>
         )}
-        {IS_WEB && <PortSelector driver={driver} setDriver={setDriver} hardware={state.deviceInfo?.hardware ?? 'v3'} />}
+        {IS_WEB && <PortSelector driver={driver} setDriver={setDriver} hardware={(driver as WebSerialDriver)?.ebb?.hardware ?? state.planOptions.hardware} />}
         <div className="section-header">pen</div>
         <div className="section-body">
           <PenHeight state={state} driver={driver} />
           <MotorControl driver={driver} />
-          <HardwareOptions state={state} />
+          <HardwareOptions state={state} driver={driver} />
           <ResetToDefaultsButton />
         </div>
         <div className="section-header">paper</div>


### PR DESCRIPTION
Closes https://github.com/alexrudd2/saxi/issues/199

Extend the current brushless checkbox to a full selector for different hardware models.

(Note: currently no way to select between `AxidrawFast` and `Axidraw`, but maybe one should just be dropped...)