### PR TITLE
Optimize hook usage and reduce calculations on re-render

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1069,7 +1069,7 @@ function Root() {
   // biome-ignore lint/correctness/useExhaustiveDependencies: currentMotionStartedTime should be re-set with each motion
   const currentMotionStartedTime = useMemo(() => {
     return new Date();
-  }, [state.progress, plan, state.paused]);
+  }, [state.progress, state.paused]);
 
   const previewArea = useRef(null);
   const previewSize = useComponentSize(previewArea);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1151,6 +1151,11 @@ function Root() {
 function DragTarget({ handleFile }: { handleFile: (file: File) => void }) {
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
+  const handleFileInputChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  }, [handleFile]);
+
   return (
     <div className="drag-target">
       <div className="drag-target-message">
@@ -1165,11 +1170,7 @@ function DragTarget({ handleFile }: { handleFile: (file: File) => void }) {
           type="file"
           accept=".svg"
           style={{ display: "none" }}
-          onChange={(e) => {
-            const file = e.target.files[0];
-            if (file) handleFile(file);
-            e.target.value = "";
-          }}
+          onChange={handleFileInputChange}
         />
       </div>
     </div>


### PR DESCRIPTION
Some hooks have too many dependencies, and run unnecessary code on re-renders.  This PR reduces them.