### PR TITLE
Eliminate moduleNameMapper from jest config

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,13 +1,3 @@
 export default {
   preset: 'ts-jest',
-  moduleNameMapper: {
-    './ebb.js': './ebb.ts',
-    './massager.js': './massager.ts',
-    './paper-size.js': './paper-size.ts',
-    './planning.js': './planning.ts',
-    './serialport-serialport.js': './serialport-serialport.ts',
-    './server.js': './server.ts',
-    './util.js': './util.ts',
-    './vec.js': './vec.ts',
-  },
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,12 @@ import { flattenSVG } from "flatten-svg";
 import { Window } from "svgdom";
 import yargs from "yargs";
 import { hideBin } from 'yargs/helpers';
-import type { Hardware } from "./ebb.js";
-import { replan } from "./massager.js";
-import { PaperSize } from "./paper-size.js";
-import { Device, type PlanOptions, defaultPlanOptions } from "./planning.js";
-import { connectEBB, startServer } from "./server.js";
-import { formatDuration } from "./util.js";
+import type { Hardware } from "./ebb";
+import { replan } from "./massager";
+import { PaperSize } from "./paper-size";
+import { Device, defaultPlanOptions, type PlanOptions } from "./planning";
+import { connectEBB, startServer } from "./server";
+import { formatDuration } from "./util";
 
 function parseSvg(svg: string) {
   const window = new Window;

--- a/src/drivers.ts
+++ b/src/drivers.ts
@@ -1,6 +1,6 @@
 
 import { EBB, type Hardware } from "./ebb";
-import { Device, PenMotion, Plan } from "./planning.js";
+import { Device, PenMotion, Plan } from "./planning";
 
 export interface DeviceInfo {
   path: string;

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -1,5 +1,5 @@
-import { type Block, type Motion, PenMotion, type Plan, XYMotion } from "./planning.js";
-import { type Vec2, vsub } from "./vec.js";
+import { type Block, type Motion, PenMotion, type Plan, XYMotion } from "./planning";
+import { type Vec2, vsub } from "./vec";
 
 enum MicrostepMode {
   DISABLED=0,

--- a/src/massager.ts
+++ b/src/massager.ts
@@ -1,8 +1,8 @@
 import type { Path } from "flatten-svg";
 import { elideShorterThan, merge as joinNearbyPaths, reorder as sortPaths } from "optimize-paths";
-import { Device, type Plan, type PlanOptions, plan } from "./planning.js";
-import { cropToMargins, dedupPoints, scaleToPaper } from "./util.js";
-import { type Vec2, vmul, vrot } from "./vec.js";
+import { Device, type Plan, type PlanOptions, plan } from "./planning";
+import { cropToMargins, dedupPoints, scaleToPaper } from "./util";
+import { type Vec2, vmul, vrot } from "./vec";
 
 
 // CSS, and thus SVG, defines 1px = 1/96th of 1in

--- a/src/paper-size.ts
+++ b/src/paper-size.ts
@@ -1,4 +1,4 @@
-import { type Vec2, vmul } from "./vec.js";
+import { type Vec2, vmul } from "./vec";
 
 function vround(v: Vec2, digits = 2): Vec2 {
   return { x: Number(v.x.toFixed(digits)), y: Number(v.y.toFixed(digits)) };

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -1,7 +1,8 @@
 // Cribbed from https://github.com/fogleman/axi/blob/master/axi/planner.py
-import type { Hardware } from './ebb.js';
-import { PaperSize } from './paper-size.js';
-import { type Vec2, vadd, vdot, vlen, vmul, vnorm, vsub } from './vec.js';
+import type { Hardware } from './ebb';
+import { PaperSize } from './paper-size';
+import { type Vec2, vadd, vdot, vlen, vmul, vnorm, vsub } from './vec';
+
 const epsilon = 1e-9;
 
 export interface PlanOptions {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,11 +15,11 @@ import type { Request, Response } from "express";
 import express from "express";
 import type WebSocket from 'ws';
 import { WebSocketServer } from 'ws';
-import { EBB, type Hardware } from './ebb.js';
-import { type Motion, PenMotion, Plan } from "./planning.js";
-import { SerialPortSerialPort } from "./serialport-serialport.js";
-import * as _self from './server.js';  // use self-import for test mocking
-import { formatDuration } from "./util.js";
+import { EBB, type Hardware } from './ebb';
+import { type Motion, PenMotion, Plan } from "./planning";
+import { SerialPortSerialPort } from "./serialport-serialport";
+import * as _self from './server';  // use self-import for test mocking
+import { formatDuration } from "./util";
 
 type Com = string
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -8,8 +8,8 @@ import { flattenSVG, type Path } from "flatten-svg";
 import React, { type ChangeEvent, Fragment, useContext, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from "react";
 import { createRoot } from 'react-dom/client';
 import { PaperSize } from "./paper-size";
-import { Device, defaultPlanOptions, type MotionData, Plan, type PlanOptions, XYMotion } from "./planning.js";
-import { formatDuration } from "./util.js";
+import { Device, defaultPlanOptions, type MotionData, Plan, type PlanOptions, XYMotion } from "./planning";
+import { formatDuration } from "./util";
 
 import "./style.css";
 import { type BaseDriver, type DeviceInfo, SaxiDriver, WebSerialDriver } from "./drivers";

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
-import type { PaperSize } from "./paper-size.js";
-import { type Vec2, vadd, vlen2, vmul, vsub } from "./vec.js";
+import type { PaperSize } from "./paper-size";
+import { type Vec2, vadd, vlen2, vmul, vsub } from "./vec";
 
 /** Format a smallish duration in 2h30m15s form */
 export function formatDuration(seconds: number): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "moduleResolution": "node",
       "esModuleInterop": true,
       "noImplicitAny": true,
-      "jsx": "react",
+      "jsx": "react"
     },
   }
   


### PR DESCRIPTION
Beside simplifying things, hopefully this should give some wiggle room for https://github.com/alexrudd2/saxi/pull/257