### PR TITLE
Remove serialization in plot planning

### DIFF
--- a/src/__tests__/planning.test.ts
+++ b/src/__tests__/planning.test.ts
@@ -68,6 +68,6 @@ describe("plan", () => {
       [{x: 10, y: 10}, {x: 25, y: 10}, {x: 30, y: 10}],
     ], AxidrawFast);
 
-    expect(p1.motions[2].duration()).toEqual(p2.motions[2].duration());
+    expect(p1.motions[2].duration).toEqual(p2.motions[2].duration);
   })
 });

--- a/src/background-planner.ts
+++ b/src/background-planner.ts
@@ -7,8 +7,5 @@ import { replan } from './massager';
 self.addEventListener("message", (m) => {
   const { paths, planOptions } = m.data;
   const plan = replan(paths, planOptions);
-  console.time("serializing");
-  const serialized = plan.serialize();
-  console.timeEnd("serializing");
-  self.postMessage(serialized);
+  self.postMessage( plan.motions );
 });

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -340,7 +340,7 @@ export class EBB {
   public async executeXYMotionWithXM(plan: XYMotion, timestepMs = 15): Promise<void> {
     const timestepSec = timestepMs / 1000;
     let t = 0;
-    while (t < plan.duration()) {
+    while (t < plan.duration) {
       const i1 = plan.instant(t);
       const i2 = plan.instant(t + timestepSec);
       const d = vsub(i2.p, i1.p);
@@ -375,9 +375,10 @@ export class EBB {
     // but rate needs to be in [clocks] / [24ms]
     // duration in units of 24ms is duration * [24ms] / [1s]
     const diff = Math.abs(pm.finalPos - pm.initialPos);
-    const durMs = pm.duration() * 1000;
+    const durMs = pm.duration * 1000;
     const rate = Math.round((diff * 24) / durMs);
-    return this.setPenHeight(pm.finalPos, rate, durMs);  }
+    return this.setPenHeight(pm.finalPos, rate, durMs);
+  }
 
   public executeMotion(m: Motion): Promise<void> {
     if (m instanceof XYMotion) {

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -325,6 +325,8 @@ export class XYMotion implements Motion {
   private ts: number[];
   private ss: number[];
   public duration: number;
+  public p1: Vec2;
+  public p2: Vec2;
 
   constructor(
     public blocks: Block[]
@@ -334,13 +336,8 @@ export class XYMotion implements Motion {
     // distance progression
     this.ss = scanLeft(blocks.map((b) => b.distance), 0, (a, b) => a + b).slice(0, -1);
     this.duration = this.blocks.map((b) => b.duration).reduce((a, b) => a + b, 0);
-  }
-
-  public get p1(): Vec2 {
-    return this.blocks[0].p1;
-  }
-  public get p2(): Vec2 {
-    return this.blocks[this.blocks.length - 1].p2;
+    this.p1 = this.blocks[0].p1;
+    this.p2 = this.blocks[this.blocks.length - 1].p2;
   }
 
   public instant(t: number): Instant {

--- a/src/server.ts
+++ b/src/server.ts
@@ -265,7 +265,7 @@ export async function startServer(port: number, hardware: Hardware = 'v3', com: 
     },
     async executeMotion(motion: Motion, progress: [number, number]): Promise<void> {
       console.log(`Motion ${progress[0] + 1}/${progress[1]}`);
-      await new Promise((resolve) => setTimeout(resolve, motion.duration() * 1000));
+      await new Promise((resolve) => setTimeout(resolve, motion.duration * 1000));
     },
     async postCancel(_initialPenHeight: number): Promise<void> {
       console.log("Plot cancelled");

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -8,7 +8,7 @@ import { flattenSVG, type Path } from "flatten-svg";
 import React, { type ChangeEvent, Fragment, useContext, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from "react";
 import { createRoot } from 'react-dom/client';
 import { PaperSize } from "./paper-size";
-import { Device, defaultPlanOptions, type MotionData, Plan, type PlanOptions, XYMotion } from "./planning.js";
+import { Device, type Motion, Plan, type PlanOptions, XYMotion, defaultPlanOptions } from "./planning.js";
 import { formatDuration } from "./util.js";
 
 import "./style.css";
@@ -164,13 +164,13 @@ const usePlan = (paths: Path[] | null, planOptions: PlanOptions) => {
     const worker = new Worker('background-planner.js');
     setIsPlanning(true);
     console.time("posting to worker");
-    // FIXME: planOptions contains Set objects which get converted to empty objects {} 
+    // FIXME: planOptions contains Set objects which get converted to empty objects {}
     // during structured cloning. Should use: { paths, planOptions: JSON.parse(serialize(planOptions)) }
     worker.postMessage({ paths, planOptions });
     console.timeEnd("posting to worker");
-    const listener = (m: Record<'data', MotionData[]>) => {
+    const listener = (msg: Record<'data', Motion[]>) => {
       console.time("deserializing");
-      const deserialized = Plan.deserialize(m.data);
+      const deserialized = Plan.deserialize(msg.data);
       console.timeEnd("deserializing");
       setPlan(deserialized);
       lastPlan.current = deserialized;
@@ -607,7 +607,7 @@ function PlanPreview(
   if (state.progress != null && plan != null) {
     const motion = plan.motion(state.progress);
     const pos = motion instanceof XYMotion
-      ? motion.instant(Math.min(microprogress / 1000, motion.duration())).p
+      ? motion.instant(Math.min(microprogress / 1000, motion.duration)).p
       : (plan.motion(state.progress - 1) as XYMotion).p2;
     const posXMm = pos.x / device.stepsPerMm;
     const posYMm = pos.y / device.stepsPerMm;


### PR DESCRIPTION
Currently a `Plan` of a plot is passed to/from a WebWorker for some calculations and then passed back.

In order to do so, it must be `serialize()`d and `deserialized()` because functions cannot be passed.  By pre-computing those functions, the serialization can be avoided.  This saves some negligible time on a powerful laptop but
(1) May be significant on a Raspberry Pi (would be great to test!)
(2) Moves towards the possibility of zero-copy to pass data to the WebWorker