### PR TITLE
Fix stuttering on dense plots: deepen the EBB motion FIFO (firmware >= 3.0.0)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -19,6 +19,9 @@ const buildOptions = {
   define: {
     IS_WEB: (process.env.IS_WEB === "1").toString(),
     "process.env.DEBUG_SAXI_COMMANDS": JSON.stringify(process.env.DEBUG_SAXI_COMMANDS ?? ""),
+    "process.env.SAXI_TELEMETRY": JSON.stringify(process.env.SAXI_TELEMETRY ?? ""),
+    "process.env.SAXI_TELEMETRY_QM": JSON.stringify(process.env.SAXI_TELEMETRY_QM ?? ""),
+    "process.env.SAXI_FIFO_DEPTH": JSON.stringify(process.env.SAXI_FIFO_DEPTH ?? ""),
   },
   plugins: [
     inlineWorker(),

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -49,10 +49,10 @@ async function waitForPlottingComplete(server: Server, timeout = 10000): Promise
   }
 }
 
-async function waitForCommandsLogged(timeout = 5000): Promise<void> {
+async function waitForCommandsLogged(command = "EM,1,1", timeout = 5000): Promise<void> {
   const startTime = Date.now();
   while (Date.now() - startTime < timeout) {
-    if (mockSerialPortInstance.commands.length > 0) break;
+    if (mockSerialPortInstance.commands.includes(command)) break;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 }

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -1,4 +1,5 @@
 import { type Block, type Motion, PenMotion, type Plan, XYMotion } from "./planning.js";
+import { PlotTelemetry } from "./telemetry.js";
 import { type Vec2, vsub } from "./vec.js";
 
 enum MicrostepMode {
@@ -23,6 +24,9 @@ type EBBCommand =
   | `XM,${number},${number},${number}` // mixed-axis move
   | `LM,${number},${number},${number},${number},${number},${number}` // low-level move
 
+  // Configure commands
+  | `CU,${number},${number}` // configure user options (e.g. CU,3,1 = red LED as empty-FIFO indicator, fw >= 2.8.1)
+
   // Servo commands
   | `S2,${number},${number}` // basic servo position
   | `S2,${number},${number},${number}` // with rate
@@ -39,7 +43,8 @@ type EBBQuery =
 type EBBQueryM =
   // queries that return multiple lines
   | "QB" // query button
-  | "QC"; // query configuration
+  | "QC" // query configuration
+  | `QU,${number}`; // query utility (fw >= 3.0.0), e.g. QU,2 = max FIFO depth
 
 /** Split d into its fractional and integral parts */
 function modf(d: number): [number, number] {
@@ -62,6 +67,7 @@ export class EBB {
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: used in constructor
   private readableClosed: Promise<void>;
   public hardware: Hardware;
+  public telemetry: PlotTelemetry | null;
 
   private microsteppingMode = MicrostepMode.DISABLED;
 
@@ -75,6 +81,9 @@ export class EBB {
     this.port = port;
     this.writer = this.port.writable.getWriter();
     this.commandQueue = [];
+    this.telemetry = process.env.SAXI_TELEMETRY
+      ? new PlotTelemetry(Number(process.env.SAXI_TELEMETRY_QM || 0))
+      : null;
 
     let buffer = "";
 
@@ -144,6 +153,12 @@ export class EBB {
       console.log(`writing: ${str}`);
     }
     const encoder = new TextEncoder();
+    if (this.telemetry) {
+      const t0 = performance.now();
+      const written = this.writer.write(encoder.encode(str));
+      written.then(() => this.telemetry?.recordWrite(performance.now() - t0)).catch(() => {});
+      return written;
+    }
     return this.writer.write(encoder.encode(str));
   }
 
@@ -190,6 +205,70 @@ export class EBB {
       });
     } catch (err) {
       throw new Error(`Error in response to command '${cmd}': ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * When telemetry is enabled, make the EBB light its red USR LED whenever the
+   * motion FIFO is empty (firmware >= 2.8.1). During a pen-down path the FIFO
+   * should never be empty, so a flickering red LED is the machine itself
+   * reporting buffer underrun, independent of any host-side timing.
+   */
+  public async setFifoLedIndicator(on: boolean): Promise<void> {
+    if (!this.telemetry) return;
+    try {
+      if ((await this.firmwareVersionCompare(2, 8, 1)) >= 0) {
+        await this.command(`CU,3,${on ? 1 : 0}`);
+        if (on) {
+          console.log("[saxi-telemetry] red USR LED on the EBB = FIFO-empty indicator (flicker during a path = underrun)");
+        }
+      } else if (on) {
+        console.log("[saxi-telemetry] firmware < 2.8.1: FIFO LED indicator (CU,3) not available");
+      }
+    } catch (err) {
+      // Diagnostic nicety only; never let it abort a plot.
+      console.log(`[saxi-telemetry] FIFO LED indicator unavailable: ${(err as Error).message}`);
+    }
+  }
+
+  /** The board's maximum motion FIFO depth (QU,2; firmware >= 3.0.0). */
+  private async maxFifoDepth(): Promise<number> {
+    try {
+      const lines = await this.queryM("QU,2");
+      const value = Number(lines[0]?.split(",").pop());
+      if (Number.isFinite(value) && value >= 1) return value;
+    } catch {
+      // fall through to a conservative depth known to be supported
+    }
+    return 32;
+  }
+
+  /**
+   * Deepen the EBB's motion FIFO (firmware >= 3.0.0).
+   *
+   * With the boot default of a 1-deep FIFO, any host stall longer than one
+   * block (GC pause, OS scheduling hiccup) starves the steppers and the
+   * carriage visibly stutters. A deeper FIFO keeps up to N commands buffered
+   * on the board, so the machine glides through host stalls. By default the
+   * FIFO is set as deep as the board supports; SAXI_FIFO_DEPTH=n overrides,
+   * and SAXI_FIFO_DEPTH=1 restores the boot default (the setting persists on
+   * the board until power-cycled, so an explicit 1 is the only reliable "off").
+   */
+  public async configureFifoDepth(): Promise<void> {
+    try {
+      const requested = Math.floor(Number(process.env.SAXI_FIFO_DEPTH || 0));
+      if ((await this.firmwareVersionCompare(3, 0, 0)) < 0) {
+        if (requested > 1) {
+          console.log("[saxi] SAXI_FIFO_DEPTH ignored: firmware < 3.0.0 has a fixed 1-deep FIFO");
+        }
+        return;
+      }
+      const depth = requested >= 1 ? requested : await this.maxFifoDepth();
+      await this.command(`CU,4,${depth}`);
+      console.log(`[saxi] EBB motion FIFO depth set to ${depth}`);
+      if (this.telemetry) this.telemetry.fifoDepth = depth;
+    } catch (err) {
+      console.log(`[saxi] failed to set FIFO depth: ${(err as Error).message}`);
     }
   }
 
@@ -336,8 +415,27 @@ export class EBB {
    * Note that the LM command is only available starting from EBB firmware version 2.5.3.
    */
   public async executeXYMotionWithLM(plan: XYMotion): Promise<void> {
-    for (const block of plan.blocks) {
-      await this.executeBlockWithLM(block);
+    const telemetry = this.telemetry;
+    telemetry?.beginMotion();
+    const qmInterval = telemetry?.qmInterval ?? 0;
+    let blockIdx = 0;
+    try {
+      for (const block of plan.blocks) {
+        if (telemetry) {
+          const t0 = performance.now();
+          await this.executeBlockWithLM(block);
+          telemetry.recordBlock(block.duration * 1000, performance.now() - t0);
+          blockIdx++;
+          if (qmInterval > 0 && blockIdx % qmInterval === 0) {
+            telemetry.recordQM(await this.query("QM"), blockIdx);
+          }
+        } else {
+          await this.executeBlockWithLM(block);
+        }
+      }
+    } finally {
+      // On cancel the loop throws mid-motion; still report what was measured.
+      telemetry?.endMotion();
     }
   }
 
@@ -401,6 +499,9 @@ export class EBB {
   }
 
   public async executePlan(plan: Plan, microsteppingMode: RunningMicrostepMode = MicrostepMode.EIGHTH): Promise<void> {
+    this.telemetry?.reset();
+    await this.setFifoLedIndicator(true);
+    await this.configureFifoDepth();
     await this.enableMotors(microsteppingMode);
 
     for (const m of plan.motions) {
@@ -408,7 +509,9 @@ export class EBB {
     }
 
     await this.waitUntilMotorsIdle();
+    await this.setFifoLedIndicator(false);
     await this.disableMotors();
+    this.telemetry?.logSummary();
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,6 +251,9 @@ export async function startServer(
 
   const realPlotter: Plotter = {
     async prePlot(initialPenHeight: number): Promise<void> {
+      ebb.telemetry?.reset();
+      await ebb.setFifoLedIndicator(true);
+      await ebb.configureFifoDepth();
       await ebb.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
       await ebb.setPenHeight(initialPenHeight, 1000, 1000);
     },
@@ -258,12 +261,17 @@ export async function startServer(
       await ebb.executeMotion(motion);
     },
     async postCancel(initialPenHeight: number): Promise<void> {
+      // The board may still be executing motion queued in its FIFO; issuing
+      // HM while moving makes the steppers grind against whatever they're doing.
+      await ebb.waitUntilMotorsIdle();
       await ebb.setPenHeight(initialPenHeight, 1000);
       await ebb.command("HM,4000"); // HM returns carriage home without 3rd and 4th arguments
     },
     async postPlot(): Promise<void> {
       await ebb.waitUntilMotorsIdle();
+      await ebb.setFifoLedIndicator(false);
       await ebb.disableMotors();
+      ebb.telemetry?.logSummary();
     },
   };
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,269 @@
+/**
+ * Lightweight timing telemetry for diagnosing stuttery plots.
+ *
+ * Each planned motion block is sent to the EBB as one serial command, and the
+ * EBB's motion FIFO is only one command deep (firmware 2.x; 3.x boots the same
+ * way). The machine moves smoothly only if every command's send->OK cycle
+ * completes faster than the previous block executes; otherwise the steppers
+ * run dry between commands and the plot stutters. This module measures exactly
+ * that.
+ *
+ * Enabled via environment variables (see EBB constructor):
+ *   SAXI_TELEMETRY=1       per-motion + end-of-plot timing summaries
+ *   SAXI_TELEMETRY_QM=200  additionally query motor/FIFO status from the
+ *                          machine every N blocks (adds one extra serial
+ *                          round-trip per sample, so it slightly perturbs
+ *                          the thing it measures)
+ */
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function fmtMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(1)}ms`;
+}
+
+/** Cycles longer than planned by more than this margin count as stalls. */
+const STALL_MARGIN_MS = 2;
+
+/** Emit a running progress line every this many blocks within a motion. */
+const PROGRESS_INTERVAL = 5000;
+
+/** Individually log any command cycle that overruns its block by this much. */
+const SLOW_EVENT_MS = 100;
+
+function ts(): string {
+  return new Date().toTimeString().slice(0, 8);
+}
+
+export class PlotTelemetry {
+  /** Sample QM (motor/FIFO status) every this many blocks; 0 = off. */
+  public qmInterval: number;
+
+  /**
+   * Motion FIFO depth configured on the board (set by EBB.configureFifoDepth).
+   * With a deep FIFO, cycles longer than planned mostly mean healthy
+   * backpressure (waiting for queue space), not starvation, so the stall
+   * numbers must be read differently.
+   */
+  public fifoDepth = 1;
+
+  private motionIdx = 0;
+  private plannedMs: number[] = [];
+  private cycleMs: number[] = [];
+  private writeMs: number[] = [];
+
+  // Totals are accumulated per-block (not per-motion) so that a cancelled
+  // plot still reports everything that was measured up to the cancel.
+  private totalBlocks = 0;
+  private totalPlannedMs = 0;
+  private totalCycleMs = 0;
+  private totalStallMs = 0;
+  private totalStallBlocks = 0;
+
+  private qmSamples = 0;
+  private qmFifoEmpty = 0;
+  private qmIdle = 0;
+
+  private lagTimer: ReturnType<typeof setInterval> | null = null;
+  private gcObserver: PerformanceObserver | null = null;
+  private slowEventsSuppressed = 0;
+  private lastSlowEventLog = 0;
+
+  constructor(qmInterval = 0) {
+    this.qmInterval = qmInterval > 0 ? Math.floor(qmInterval) : 0;
+  }
+
+  /**
+   * Start host-side probes that run independently of the serial traffic:
+   * an event-loop lag monitor and (in Node) a GC pause observer. Together
+   * with the per-block timings these tell apart "host froze" (lag + GC lines
+   * coincide with slow blocks) from "serial link is slow" (slow blocks alone).
+   */
+  private startProbes(): void {
+    if (this.lagTimer == null) {
+      let last = performance.now();
+      this.lagTimer = setInterval(() => {
+        const now = performance.now();
+        const lag = now - last - 50;
+        last = now;
+        if (lag > 50) {
+          console.log(`[saxi-telemetry] ${ts()} event-loop stall: ${lag.toFixed(0)}ms`);
+        }
+      }, 50);
+      // Don't keep the process alive for the probe (Node-only API).
+      (this.lagTimer as { unref?: () => void }).unref?.();
+    }
+    if (this.gcObserver == null && typeof PerformanceObserver !== "undefined") {
+      try {
+        const observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            if (entry.duration > 20) {
+              console.log(`[saxi-telemetry] ${ts()} GC pause: ${entry.duration.toFixed(0)}ms`);
+            }
+          }
+        });
+        observer.observe({ entryTypes: ["gc"] });
+        this.gcObserver = observer;
+      } catch {
+        // 'gc' entries unsupported (e.g. browsers); skip.
+        this.gcObserver = null;
+      }
+    }
+  }
+
+  /** Forget everything; call at the start of each plot. */
+  public reset(): void {
+    this.motionIdx = 0;
+    this.plannedMs = [];
+    this.cycleMs = [];
+    this.writeMs = [];
+    this.totalBlocks = 0;
+    this.totalPlannedMs = 0;
+    this.totalCycleMs = 0;
+    this.totalStallMs = 0;
+    this.totalStallBlocks = 0;
+    this.qmSamples = 0;
+    this.qmFifoEmpty = 0;
+    this.qmIdle = 0;
+    this.slowEventsSuppressed = 0;
+    this.lastSlowEventLog = 0;
+    this.startProbes();
+    console.log("[saxi-telemetry] enabled (stall = command cycle exceeding planned block duration)");
+  }
+
+  public beginMotion(): void {
+    this.plannedMs = [];
+    this.cycleMs = [];
+  }
+
+  /**
+   * Record one executed block: its planned duration vs the wall-clock time the
+   * full send->OK command cycle took.
+   */
+  public recordBlock(plannedDurationMs: number, commandCycleMs: number): void {
+    this.plannedMs.push(plannedDurationMs);
+    this.cycleMs.push(commandCycleMs);
+    this.totalBlocks++;
+    this.totalPlannedMs += plannedDurationMs;
+    this.totalCycleMs += commandCycleMs;
+    const over = commandCycleMs - plannedDurationMs;
+    if (over > STALL_MARGIN_MS) {
+      this.totalStallMs += over;
+      this.totalStallBlocks++;
+    }
+    if (over > SLOW_EVENT_MS) {
+      // Rate-limit to one line per second; aggregate the rest.
+      const now = performance.now();
+      if (now - this.lastSlowEventLog > 1000) {
+        const suppressed = this.slowEventsSuppressed > 0 ? ` (+${this.slowEventsSuppressed} more in the last second)` : "";
+        console.log(
+          `[saxi-telemetry] ${ts()} slow block: cycle ${fmtMs(commandCycleMs)} vs planned ${fmtMs(plannedDurationMs)} ` +
+            `at motion ${this.motionIdx + 1} block ${this.cycleMs.length}${suppressed}`,
+        );
+        this.lastSlowEventLog = now;
+        this.slowEventsSuppressed = 0;
+      } else {
+        this.slowEventsSuppressed++;
+      }
+    }
+    if (this.cycleMs.length % PROGRESS_INTERVAL === 0) {
+      console.log(
+        `[saxi-telemetry] motion ${this.motionIdx + 1} progress: ${this.cycleMs.length} blocks | ` +
+          `plot-wide stalled blocks so far: ${this.totalStallBlocks} totaling ${fmtMs(this.totalStallMs)}`,
+      );
+    }
+  }
+
+  /** Record how long a serial write took to be accepted by the OS driver. */
+  public recordWrite(ms: number): void {
+    this.writeMs.push(ms);
+  }
+
+  /**
+   * Record a QM response sampled mid-motion. At that point the machine should
+   * be busy (command executing, FIFO occupied); an idle response is
+   * machine-side proof of a buffer underrun, and "executing with empty FIFO"
+   * means the buffer is on the verge of running dry.
+   */
+  public recordQM(response: string, blockIdx: number): void {
+    const [, commandStatus, , , fifoStatus] = response.split(",");
+    this.qmSamples++;
+    if (fifoStatus === "0") this.qmFifoEmpty++;
+    if (commandStatus === "0") {
+      this.qmIdle++;
+      console.log(`[saxi-telemetry] QM @ motion ${this.motionIdx + 1} block ${blockIdx}: machine IDLE mid-path (underrun confirmed)`);
+    }
+  }
+
+  /** Print stats for the current motion; safe to call after a cancel. */
+  public endMotion(): void {
+    const n = this.cycleMs.length;
+    this.motionIdx++;
+    // Pen-up travel moves are also XY motions; only report on substantial ones.
+    if (n < 10) return;
+
+    let planned = 0;
+    let cycle = 0;
+    let stallMs = 0;
+    let stallBlocks = 0;
+    for (let i = 0; i < n; i++) {
+      planned += this.plannedMs[i];
+      cycle += this.cycleMs[i];
+      const over = this.cycleMs[i] - this.plannedMs[i];
+      if (over > STALL_MARGIN_MS) {
+        stallMs += over;
+        stallBlocks++;
+      }
+    }
+
+    const sorted = [...this.cycleMs].sort((a, b) => a - b);
+    console.log(
+      `[saxi-telemetry] motion ${this.motionIdx}: ${n} blocks | ` +
+        `planned ${fmtMs(planned)}, actual ${fmtMs(cycle)} (${cycle >= planned ? "+" : ""}${fmtMs(cycle - planned)}) | ` +
+        `stalled blocks: ${stallBlocks} (${((stallBlocks / n) * 100).toFixed(1)}%) totaling ${fmtMs(stallMs)} | ` +
+        `cycle p50 ${fmtMs(percentile(sorted, 50))} p95 ${fmtMs(percentile(sorted, 95))} max ${fmtMs(sorted[n - 1])}`,
+    );
+  }
+
+  /** Print the whole-plot summary; call once plotting finishes or is cancelled. */
+  public logSummary(): void {
+    if (this.totalBlocks === 0) return;
+    const behind = this.totalCycleMs - this.totalPlannedMs;
+    console.log(
+      `[saxi-telemetry] PLOT SUMMARY: ${this.totalBlocks} blocks | ` +
+        `planned ${fmtMs(this.totalPlannedMs)}, actual ${fmtMs(this.totalCycleMs)} ` +
+        `(${behind >= 0 ? "+" : ""}${((behind / Math.max(1, this.totalPlannedMs)) * 100).toFixed(1)}% vs plan) | ` +
+        `stalled blocks: ${this.totalStallBlocks} (${((this.totalStallBlocks / this.totalBlocks) * 100).toFixed(1)}%), ` +
+        `total stall time ${fmtMs(this.totalStallMs)}`,
+    );
+    if (this.writeMs.length > 0) {
+      const sorted = [...this.writeMs].sort((a, b) => a - b);
+      console.log(
+        `[saxi-telemetry] serial writes: ${sorted.length} | ` +
+          `p50 ${fmtMs(percentile(sorted, 50))} p95 ${fmtMs(percentile(sorted, 95))} max ${fmtMs(sorted[sorted.length - 1])}`,
+      );
+    }
+    if (this.qmSamples > 0) {
+      console.log(
+        `[saxi-telemetry] QM samples: ${this.qmSamples} | ` +
+          `FIFO empty: ${this.qmFifoEmpty} | machine idle mid-path: ${this.qmIdle}`,
+      );
+    }
+    if (this.fifoDepth > 1) {
+      console.log(
+        `[saxi-telemetry] note: FIFO depth is ${this.fifoDepth}, so stalled-block counts mostly reflect ` +
+          "healthy backpressure pacing; judge smoothness by actual-vs-plan, the FIFO LED, and QM idle counts.",
+      );
+    } else if (this.totalStallMs > 1000) {
+      console.log(
+        "[saxi-telemetry] diagnosis hint: significant stall time means command cycles can't keep up with " +
+          "block durations -> the EBB's 1-deep FIFO runs dry between commands (visible as stutter). " +
+          "Shorter blocks (denser SVG paths) make this worse.",
+      );
+    }
+  }
+}

--- a/tools/analyze-plan.mjs
+++ b/tools/analyze-plan.mjs
@@ -1,0 +1,72 @@
+// Offline analysis of the motion plan saxi would generate for an SVG.
+// Runs the same parse -> flatten -> replan pipeline as `saxi plot`, then
+// reports block-duration statistics. Each block becomes one LM serial
+// command, so blocks shorter than the serial round-trip time are at risk
+// of starving the EBB's 1-deep motion FIFO (visible as stutter).
+//
+// Usage: node tools/analyze-plan.mjs <file.svg> [roundTripMs]
+
+import { readFileSync } from "node:fs";
+import { flattenSVG } from "flatten-svg";
+import { createSVGWindow } from "svgdom";
+import { replan } from "../dist/server/massager.js";
+import { PaperSize } from "../dist/server/paper-size.js";
+import { defaultPlanOptions } from "../dist/server/planning.js";
+
+const file = process.argv[2];
+const assumedRoundTripMs = Number(process.argv[3] ?? 4);
+if (!file) {
+  console.error("usage: node tools/analyze-plan.mjs <file.svg> [roundTripMs]");
+  process.exit(1);
+}
+
+function parseSvg(svg) {
+  const window = createSVGWindow();
+  window.document.documentElement.innerHTML = svg;
+  return window.document.documentElement;
+}
+
+console.error(`reading ${file}...`);
+const svg = readFileSync(file, "utf8");
+console.error("parsing & flattening...");
+const lines = flattenSVG(parseSvg(svg), {});
+console.error(`flattened to ${lines.length} polylines`);
+const points = lines.reduce((n, l) => n + l.points.length, 0);
+console.error(`total points: ${points}`);
+
+console.error("planning (same options as UI/CLI defaults, ArchA landscape)...");
+const planOptions = { ...defaultPlanOptions, layerMode: "all", paperSize: PaperSize.standard.ArchA.landscape };
+const plan = replan(lines, planOptions);
+
+const durationsMs = [];
+let xyMotions = 0;
+let penMotions = 0;
+for (const motion of plan.motions) {
+  if ("blocks" in motion) {
+    xyMotions++;
+    for (const b of motion.blocks) durationsMs.push(b.duration * 1000);
+  } else {
+    penMotions++;
+  }
+}
+
+durationsMs.sort((a, b) => a - b);
+const total = durationsMs.length;
+const sum = durationsMs.reduce((a, b) => a + b, 0);
+const pct = (p) => durationsMs[Math.min(total - 1, Math.floor((p / 100) * total))];
+const below = (ms) => durationsMs.filter((d) => d < ms).length;
+
+console.log(`\n=== ${file} ===`);
+console.log(`motions: ${plan.motions.length} (${xyMotions} XY, ${penMotions} pen)`);
+console.log(`blocks (= LM serial commands): ${total}`);
+console.log(`plan duration: ${(sum / 1000).toFixed(1)} s`);
+console.log(`block duration: median ${pct(50).toFixed(2)} ms, p10 ${pct(10).toFixed(2)} ms, p90 ${pct(90).toFixed(2)} ms`);
+for (const ms of [1, 2, 4, 8, 15, 30]) {
+  const n = below(ms);
+  console.log(`  blocks < ${String(ms).padStart(2)} ms: ${String(n).padStart(7)}  (${((n / total) * 100).toFixed(1)}%)`);
+}
+const atRisk = below(assumedRoundTripMs);
+console.log(
+  `\nwith an assumed serial round-trip of ${assumedRoundTripMs} ms, ` +
+    `${atRisk} blocks (${((atRisk / total) * 100).toFixed(1)}%) finish before the next command can arrive -> FIFO underrun risk`,
+);


### PR DESCRIPTION
## Problem

Long/dense paths make the AxiDraw stutter and judder (nornagon/saxi#44, open since 2020). Dense SVGs plan into thousands of very short motion blocks (~10-20 ms each), and each block is sent as one `LM` command with a send/OK round trip. The EBB's motion FIFO boots **1 command deep**, so any host stall longer than one block leaves the steppers with nothing to execute - they physically halt until the next command lands. Node GC pauses and OS scheduling hiccups of 50-800 ms are routine (measured on Windows 10 / Node 24), so dense plots stutter constantly while sparse ones (longer blocks) are fine.

## Fix

- At plot start (both the server path and `executePlan`), query the board's maximum FIFO depth (`QU,2`) and set it (`CU,4`) when firmware >= 3.0.0. With 32+ commands buffered on the board, the machine glides through host stalls. The existing send-then-await-OK loop automatically keeps the host ahead, since the EBB acks instantly while its FIFO has room.
- `SAXI_FIFO_DEPTH=n` overrides the depth; `=1` restores the boot default. (The setting persists on the board until power-cycle, so an explicit 1 is the only reliable "off".)
- Firmware < 3.0.0: no behavior change (the FIFO isn't configurable there, which is why this issue never had a good host-side fix).
- Cancel fix: `postCancel` now waits for queued motion to finish before sending `HM`. Previously HM was issued while the board was still executing buffered moves, grinding the steppers; a deeper FIFO widens that window, so this ships together.

## Diagnostics (opt-in, used to find this)

- `SAXI_TELEMETRY=1` - times every command cycle against its planned block duration, reports per-motion and per-plot summaries (planned vs actual, stalled blocks, cycle percentiles, serial write latency), logs GC pauses and event-loop stalls with timestamps, and enables the EBB's red-LED FIFO-empty indicator (`CU,3`, firmware >= 2.8.1) so the board itself shows underruns in real time.
- `SAXI_TELEMETRY_QM=n` - additionally samples `QM` every n blocks for machine-side FIFO/idle status.
- `tools/analyze-plan.mjs <file.svg>` - offline block-duration distribution for an SVG (no hardware needed).

## Evidence

A/B on the same dense file (one continuous path, ~66k blocks @ ~18 ms), same machine, same measured GC load:

| | FIFO depth 1 | FIFO depth 32 |
|---|---|---|
| Observed | stutters from the start, throughout | smooth |
| Micro-stalls (cycle > block + 2 ms) | 2,627 totaling 13.7 s | absorbed |
| QM machine-side | FIFO caught empty | 0 idle / 0 empty (132 samples) |
| Actual vs planned duration | +0.4% as visible jerks | +0.4% hidden in backpressure |

A measured 99 ms GC pause mid-plot at depth 32 produced no visible effect; the same class of pause at depth 1 is a visible hiccup with the red LED flashing.

## Notes

- Tests: `waitForCommandsLogged` now waits for the asserted command (the FIFO config adds a `V` query before `EM`, which exposed the race).
- The browser/WebSerial build gets the same code; env defines added in `build.mjs` (telemetry stays off there unless baked in at build time).
