### PR TITLE
Deepen the EBB motion FIFO on dense plots (firmware >= 3.0.0)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -19,6 +19,7 @@ const buildOptions = {
   define: {
     IS_WEB: (process.env.IS_WEB === "1").toString(),
     "process.env.DEBUG_SAXI_COMMANDS": JSON.stringify(process.env.DEBUG_SAXI_COMMANDS ?? ""),
+    "process.env.SAXI_FIFO_DEPTH": JSON.stringify(process.env.SAXI_FIFO_DEPTH ?? ""),
   },
   plugins: [
     inlineWorker(),

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -23,6 +23,9 @@ type EBBCommand =
   | `XM,${number},${number},${number}` // mixed-axis move
   | `LM,${number},${number},${number},${number},${number},${number}` // low-level move
 
+  // Configure commands
+  | `CU,${number},${number}` // configure user options (e.g. CU,4,n = motion FIFO depth, fw >= 3.0.0)
+
   // Servo commands
   | `S2,${number},${number}` // basic servo position
   | `S2,${number},${number},${number}` // with rate
@@ -39,7 +42,8 @@ type EBBQuery =
 type EBBQueryM =
   // queries that return multiple lines
   | "QB" // query button
-  | "QC"; // query configuration
+  | "QC" // query configuration
+  | `QU,${number}`; // query utility (fw >= 3.0.0), e.g. QU,2 = max FIFO depth
 
 /** Split d into its fractional and integral parts */
 function modf(d: number): [number, number] {
@@ -190,6 +194,46 @@ export class EBB {
       });
     } catch (err) {
       throw new Error(`Error in response to command '${cmd}': ${(err as Error).message}`);
+    }
+  }
+
+  /** The board's maximum motion FIFO depth (QU,2; firmware >= 3.0.0). */
+  private async maxFifoDepth(): Promise<number> {
+    try {
+      const lines = await this.queryM("QU,2");
+      const value = Number(lines[0]?.split(",").pop());
+      if (Number.isFinite(value) && value >= 1) return value;
+    } catch {
+      // fall through to a conservative depth known to be supported
+    }
+    return 32;
+  }
+
+  /**
+   * Deepen the EBB's motion FIFO (firmware >= 3.0.0).
+   *
+   * With the boot default of a 1-deep FIFO, any host stall longer than one
+   * block (GC pause, OS scheduling hiccup) starves the steppers and the
+   * carriage visibly stutters. A deeper FIFO keeps up to N commands buffered
+   * on the board, so the machine glides through host stalls. By default the
+   * FIFO is set as deep as the board supports; SAXI_FIFO_DEPTH=n overrides,
+   * and SAXI_FIFO_DEPTH=1 restores the boot default (the setting persists on
+   * the board until power-cycled, so an explicit 1 is the only reliable "off").
+   */
+  public async configureFifoDepth(): Promise<void> {
+    try {
+      const requested = Math.floor(Number(process.env.SAXI_FIFO_DEPTH || 0));
+      if ((await this.firmwareVersionCompare(3, 0, 0)) < 0) {
+        if (requested > 1) {
+          console.log("[saxi] SAXI_FIFO_DEPTH ignored: firmware < 3.0.0 has a fixed 1-deep FIFO");
+        }
+        return;
+      }
+      const depth = requested >= 1 ? requested : await this.maxFifoDepth();
+      await this.command(`CU,4,${depth}`);
+      console.log(`[saxi] EBB motion FIFO depth set to ${depth}`);
+    } catch (err) {
+      console.log(`[saxi] failed to set FIFO depth: ${(err as Error).message}`);
     }
   }
 
@@ -401,6 +445,7 @@ export class EBB {
   }
 
   public async executePlan(plan: Plan, microsteppingMode: RunningMicrostepMode = MicrostepMode.EIGHTH): Promise<void> {
+    await this.configureFifoDepth();
     await this.enableMotors(microsteppingMode);
 
     for (const m of plan.motions) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,6 +251,7 @@ export async function startServer(
 
   const realPlotter: Plotter = {
     async prePlot(initialPenHeight: number): Promise<void> {
+      await ebb.configureFifoDepth();
       await ebb.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
       await ebb.setPenHeight(initialPenHeight, 1000, 1000);
     },
@@ -258,6 +259,9 @@ export async function startServer(
       await ebb.executeMotion(motion);
     },
     async postCancel(initialPenHeight: number): Promise<void> {
+      // The board may still be executing motion queued in its FIFO; issuing
+      // HM while moving makes the steppers grind against whatever they're doing.
+      await ebb.waitUntilMotorsIdle();
       await ebb.setPenHeight(initialPenHeight, 1000);
       await ebb.command("HM,4000"); // HM returns carriage home without 3rd and 4th arguments
     },


### PR DESCRIPTION
## Problem

Long/dense paths make the AxiDraw stutter and judder (nornagon/saxi#44, open since 2020). Dense SVGs plan into thousands of very short motion blocks (~10-20 ms each), and each block is sent as one `LM` command with a send/OK round trip. The EBB's motion FIFO boots **1 command deep**, so any host stall longer than one block leaves the steppers with nothing to execute — they physically halt until the next command lands. Node GC pauses and OS scheduling hiccups of 50-800 ms are routine (measured on Windows 10 / Node 24), so dense plots stutter constantly while sparse ones (longer blocks) are fine.

## Fix

- At plot start (both the server path and `executePlan`), query the board's maximum FIFO depth (`QU,2`) and set it (`CU,4`) when firmware >= 3.0.0. With 32+ commands buffered on the board, the machine glides through host stalls. The existing send-then-await-OK loop automatically keeps the host ahead, since the EBB acks instantly while its FIFO has room.
- `SAXI_FIFO_DEPTH=n` overrides the depth; `=1` restores the boot default. (The setting persists on the board until power-cycle, so an explicit 1 is the only reliable "off".)
- Firmware < 3.0.0: no behavior change (the FIFO isn't configurable there, which is why this issue never had a good host-side fix).
- **Cancel fix:** `postCancel` now waits for queued motion to finish before sending `HM`. Previously HM was issued while the board was still executing buffered moves, grinding the steppers; a deeper FIFO widens that window, so this ships together.

## Evidence

A/B on the same dense file (one continuous path, ~66k blocks @ ~18 ms), same machine, same measured GC load:

| | FIFO depth 1 | FIFO depth 32 |
|---|---|---|
| Observed | stutters from the start, throughout | smooth |
| Micro-stalls (cycle > block + 2 ms) | 2,627 totaling 13.7 s | absorbed |
| QM machine-side | FIFO caught empty | 0 idle / 0 empty (132 samples) |
| Actual vs planned duration | +0.4% as visible jerks | +0.4% hidden in backpressure |

## Notes

This is the first of three PRs split out of #305 (which I'll close). The other two — opt-in telemetry and an offline `analyze-plan` tool — are the diagnostics used to find and verify this fix; they're follow-ups and not needed to land the fix itself. The test-robustness change from #305 already merged separately as a860cb7.

The browser/WebSerial build gets the same code; the `SAXI_FIFO_DEPTH` env define is added in `build.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)