### PR TITLE
perf(server): run the EBB on a dedicated serial worker thread

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -19,6 +19,8 @@ const buildOptions = {
   define: {
     IS_WEB: (process.env.IS_WEB === "1").toString(),
     "process.env.DEBUG_SAXI_COMMANDS": JSON.stringify(process.env.DEBUG_SAXI_COMMANDS ?? ""),
+    "process.env.SAXI_TELEMETRY": JSON.stringify(process.env.SAXI_TELEMETRY ?? ""),
+    "process.env.SAXI_TELEMETRY_QM": JSON.stringify(process.env.SAXI_TELEMETRY_QM ?? ""),
     "process.env.SAXI_FIFO_DEPTH": JSON.stringify(process.env.SAXI_FIFO_DEPTH ?? ""),
   },
   plugins: [

--- a/src/__tests__/ebb-proxy.test.ts
+++ b/src/__tests__/ebb-proxy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, vi } from "vitest";
+import { createEbbProxy } from "../ebb-proxy";
+import { createMockSerialPort, mockSerialPortInstance } from "./mocks/serialport";
+
+// Under vitest, createEbbProxy runs the worker host in-process, so this mock
+// (and its shared command log) apply to the EBB the host opens.
+vi.mock("../serialport-serialport", () => ({
+  SerialPortSerialPort: vi.fn(function SerialPortSerialPort() {
+    return createMockSerialPort();
+  }),
+}));
+
+async function waitFor(predicate: () => boolean, timeout = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for condition");
+}
+
+describe("EbbProxy <-> worker host RPC", () => {
+  test("connects, forwards commands, returns query results, and cancels", async () => {
+    mockSerialPortInstance.clearCommands();
+    const proxy = await createEbbProxy({ com: "/dev/ttyMOCK", hardware: "v3" });
+
+    // The host's reconnect loop opens the (mock) port and reports the device up.
+    await waitFor(() => proxy.connected);
+    expect(proxy.devicePath).toBe(null); // the mock has no real path
+
+    // A command RPC round-trips and is written to the port.
+    await proxy.enableMotors(1);
+    expect(mockSerialPortInstance.commands).toContain("EM,1,1");
+
+    // A query RPC returns a value. The mock reports firmware 2.5.3 (< 2.6.0).
+    await expect(proxy.supportsSR()).resolves.toBe(false);
+
+    // Method args are forwarded in order: S2,<height>,<pin>,<rate>,<delay>.
+    await proxy.setPenHeight(1000, 500);
+    expect(mockSerialPortInstance.commands.some((c) => c.startsWith("S2,1000,4,500"))).toBe(true);
+
+    // Cancel is delivered out-of-band and does not throw.
+    expect(() => proxy.cancel()).not.toThrow();
+
+    await proxy.terminate();
+  });
+});

--- a/src/ebb-proxy.ts
+++ b/src/ebb-proxy.ts
@@ -1,0 +1,171 @@
+/**
+ * Main-thread proxy for the serial worker.
+ *
+ * Mirrors the subset of the EBB API the web server uses, forwarding each call
+ * to the worker as an `{id, method, args}` message and resolving on the
+ * matching reply. The server keeps its existing shape; `ebb` just becomes this
+ * proxy. The streaming loop that must not be interrupted lives behind it, in
+ * the worker.
+ *
+ * Transport is a real worker_thread in production and an in-process host under
+ * vitest (so the serial-port mock and its shared command log keep working
+ * without a thread boundary).
+ */
+import { EventEmitter } from "node:events";
+import type { Hardware } from "./ebb.js";
+import type { EbbHostOptions, EbbMethod, MainToWorker, WorkerToMain } from "./ebb-rpc.js";
+import type { Motion } from "./planning.js";
+
+interface Transport {
+  postMessage(msg: MainToWorker): void;
+  terminate(): Promise<void>;
+}
+
+type Pending = { resolve: (value: unknown) => void; reject: (error: Error) => void };
+
+export class EbbProxy extends EventEmitter {
+  private transport: Transport | null = null;
+  private pending = new Map<number, Pending>();
+  private nextId = 1;
+
+  /** Latest device state, kept in sync from the worker's `dev` events. */
+  public connected = false;
+  public devicePath: string | null = null;
+  public hardware: Hardware;
+
+  constructor(hardware: Hardware) {
+    super();
+    this.hardware = hardware;
+  }
+
+  /** Wire up the transport (called by createEbbProxy once it is built). */
+  public attachTransport(transport: Transport): void {
+    this.transport = transport;
+  }
+
+  /** Handle a message coming back from the worker/host. */
+  public receive(msg: WorkerToMain): void {
+    switch (msg.kind) {
+      case "result": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.resolve(msg.value);
+        break;
+      }
+      case "error": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.reject(new Error(msg.error));
+        break;
+      }
+      case "dev": {
+        this.connected = msg.connected;
+        this.devicePath = msg.path;
+        this.hardware = msg.hardware;
+        this.emit("dev");
+        break;
+      }
+    }
+  }
+
+  private call(method: EbbMethod, ...args: unknown[]): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.transport) {
+        reject(new Error("EBB proxy transport not attached"));
+        return;
+      }
+      const id = this.nextId++;
+      this.pending.set(id, { resolve, reject });
+      this.transport.postMessage({ kind: "call", id, method, args });
+    });
+  }
+
+  // --- EBB API surface used by the web server ---
+
+  public executeMotion(motion: Motion): Promise<void> {
+    return this.call("executeMotion", motion.serialize()) as Promise<void>;
+  }
+  public setPenHeight(height: number, rate: number, delay?: number): Promise<void> {
+    return this.call("setPenHeight", height, rate, delay) as Promise<void>;
+  }
+  public setServoPowerTimeout(timeout: number, power?: boolean): Promise<void> {
+    return this.call("setServoPowerTimeout", timeout, power) as Promise<void>;
+  }
+  public supportsSR(): Promise<boolean> {
+    return this.call("supportsSR") as Promise<boolean>;
+  }
+  public enableMotors(microsteppingMode: number): Promise<void> {
+    return this.call("enableMotors", microsteppingMode) as Promise<void>;
+  }
+  public disableMotors(): Promise<void> {
+    return this.call("disableMotors") as Promise<void>;
+  }
+  public setFifoLedIndicator(on: boolean): Promise<void> {
+    return this.call("setFifoLedIndicator", on) as Promise<void>;
+  }
+  public configureFifoDepth(): Promise<void> {
+    return this.call("configureFifoDepth") as Promise<void>;
+  }
+  public waitUntilMotorsIdle(): Promise<void> {
+    return this.call("waitUntilMotorsIdle") as Promise<void>;
+  }
+  public command(cmd: string): Promise<void> {
+    return this.call("command", cmd) as Promise<void>;
+  }
+  public resetTelemetry(): Promise<void> {
+    return this.call("resetTelemetry") as Promise<void>;
+  }
+  public logTelemetrySummary(): Promise<void> {
+    return this.call("logTelemetrySummary") as Promise<void>;
+  }
+
+  /** Synchronous, like EBB.changeHardware: update the cache, push to the worker. */
+  public changeHardware(hardware: Hardware): void {
+    this.hardware = hardware;
+    this.call("changeHardware", hardware).catch(() => {});
+  }
+
+  /** Out-of-band cancel: applied immediately in the worker, ahead of any queue. */
+  public cancel(): void {
+    this.transport?.postMessage({ kind: "cancel" });
+  }
+
+  public async terminate(): Promise<void> {
+    await this.transport?.terminate();
+  }
+}
+
+/**
+ * Build a proxy and its transport. Under vitest the host runs in-process so the
+ * serial-port mock applies; otherwise the host runs in a real worker_thread.
+ */
+export async function createEbbProxy(options: EbbHostOptions): Promise<EbbProxy> {
+  const proxy = new EbbProxy(options.hardware);
+
+  if (process.env.VITEST) {
+    const { createEbbHost } = await import("./ebb-worker.js");
+    const host = createEbbHost(options, (msg) => proxy.receive(msg));
+    proxy.attachTransport({
+      postMessage: (msg) => host.handleMessage(msg),
+      terminate: () => host.terminate(),
+    });
+  } else {
+    const { Worker } = await import("node:worker_threads");
+    const worker = new Worker(new URL("./ebb-worker.js", import.meta.url), { workerData: options });
+    let terminating = false;
+    worker.on("message", (msg: WorkerToMain) => proxy.receive(msg));
+    worker.on("error", (e) => console.error(`[ebb-worker] error: ${e.message}`));
+    worker.on("exit", (code) => {
+      if (code !== 0 && !terminating) console.error(`[ebb-worker] exited with code ${code}`);
+    });
+    proxy.attachTransport({
+      postMessage: (msg) => worker.postMessage(msg),
+      terminate: async () => {
+        terminating = true;
+        await worker.terminate();
+      },
+    });
+  }
+
+  return proxy;
+}

--- a/src/ebb-rpc.ts
+++ b/src/ebb-rpc.ts
@@ -1,0 +1,48 @@
+/**
+ * Message protocol between the main thread (ebb-proxy.ts) and the serial worker
+ * (ebb-worker.ts).
+ *
+ * Granularity is one RPC per method call (one per motion during a plot), not
+ * one per serial command: a motion's entire send->OK->send block stream runs
+ * inside the worker, so postMessage latency never sits inside the serial cycle.
+ */
+import type { Hardware } from "./ebb.js";
+import type { MotionData } from "./planning.js";
+
+export interface EbbHostOptions {
+  com?: string;
+  hardware: Hardware;
+}
+
+/** The EBB methods the web server invokes through the proxy. */
+export type EbbMethod =
+  | "executeMotion"
+  | "setPenHeight"
+  | "setServoPowerTimeout"
+  | "supportsSR"
+  | "enableMotors"
+  | "disableMotors"
+  | "setFifoLedIndicator"
+  | "configureFifoDepth"
+  | "waitUntilMotorsIdle"
+  | "command"
+  | "changeHardware"
+  | "resetTelemetry"
+  | "logTelemetrySummary";
+
+export type MainToWorker =
+  | { kind: "call"; id: number; method: EbbMethod; args: unknown[] }
+  // Out-of-band: the worker's event loop is free between serial replies, so a
+  // cancel is delivered and applied immediately, not queued behind the
+  // in-flight motion RPC.
+  | { kind: "cancel" };
+
+export type WorkerToMain =
+  | { kind: "result"; id: number; value: unknown }
+  | { kind: "error"; id: number; error: string }
+  // Connection state. `connected` is the source of truth (the mock serial port
+  // has no path, yet is "connected"); `path` is the serial path for display.
+  | { kind: "dev"; connected: boolean; path: string | null; hardware: Hardware };
+
+/** A serialized motion as carried over the wire by an executeMotion call. */
+export type MotionPayload = MotionData;

--- a/src/ebb-worker.ts
+++ b/src/ebb-worker.ts
@@ -1,0 +1,132 @@
+/**
+ * Serial worker host.
+ *
+ * Owns the serial port, the EBB instance, its telemetry, and the reconnect
+ * loop. When loaded as a worker_thread it self-wires to parentPort; the
+ * in-process transport (used under vitest) calls createEbbHost directly so the
+ * serial-port mock still applies. The EBB class is untouched and stays
+ * unit-testable in isolation.
+ *
+ * The point of the worker: a motion's send->OK->send block stream runs entirely
+ * on this thread's event loop and heap, so express/ws/JSON/GC on the main
+ * thread can no longer inject a multi-millisecond stall into the serial cycle —
+ * the stutter that starves a 1-deep FIFO (firmware 2.x).
+ */
+import type { EBB, Hardware } from "./ebb.js";
+import type { EbbHostOptions, EbbMethod, MainToWorker, WorkerToMain } from "./ebb-rpc.js";
+import { type Motion, type MotionData, PenMotion, XYMotion } from "./planning.js";
+import { ebbs } from "./serial-device.js";
+
+export interface EbbHost {
+  handleMessage(msg: MainToWorker): void;
+  terminate(): Promise<void>;
+}
+
+function deserializeMotion(data: MotionData): Motion {
+  if ("blocks" in data) return XYMotion.deserialize(data);
+  if ("initialPos" in data) return PenMotion.deserialize(data);
+  throw new Error(`Unknown motion payload: ${JSON.stringify(data)}`);
+}
+
+// The serial path the EBB opened, for the device-info broadcast. Mirrors the
+// private-field read server.ts used before the worker existed.
+function portPath(ebb: EBB): string | null {
+  // biome-ignore lint/suspicious/noExplicitAny: read the SerialPortSerialPort's private path
+  return (ebb.port as any)?._path ?? null;
+}
+
+export function createEbbHost(options: EbbHostOptions, postToMain: (msg: WorkerToMain) => void): EbbHost {
+  let currentEbb: EBB | null = null;
+  let hardware: Hardware = options.hardware;
+  let stopped = false;
+
+  const requireEbb = (): EBB => {
+    if (!currentEbb) throw new Error("No EBB connected");
+    return currentEbb;
+  };
+
+  async function dispatch(method: EbbMethod, args: unknown[]): Promise<unknown> {
+    switch (method) {
+      case "executeMotion":
+        return requireEbb().executeMotion(deserializeMotion(args[0] as MotionData));
+      case "setPenHeight":
+        return requireEbb().setPenHeight(args[0] as number, args[1] as number, args[2] as number | undefined);
+      case "setServoPowerTimeout":
+        return requireEbb().setServoPowerTimeout(args[0] as number, args[1] as boolean | undefined);
+      case "supportsSR":
+        return requireEbb().supportsSR();
+      case "enableMotors":
+        // biome-ignore lint/suspicious/noExplicitAny: RunningMicrostepMode is a numeric enum
+        return requireEbb().enableMotors(args[0] as any);
+      case "disableMotors":
+        return requireEbb().disableMotors();
+      case "setFifoLedIndicator":
+        return requireEbb().setFifoLedIndicator(args[0] as boolean);
+      case "configureFifoDepth":
+        return requireEbb().configureFifoDepth();
+      case "waitUntilMotorsIdle":
+        return requireEbb().waitUntilMotorsIdle();
+      case "command":
+        // biome-ignore lint/suspicious/noExplicitAny: caller passes a valid EBBCommand
+        return requireEbb().command(args[0] as any);
+      case "changeHardware":
+        hardware = args[0] as Hardware;
+        currentEbb?.changeHardware(hardware);
+        return undefined;
+      case "resetTelemetry":
+        currentEbb?.telemetry?.reset();
+        return undefined;
+      case "logTelemetrySummary":
+        currentEbb?.telemetry?.logSummary();
+        return undefined;
+      default:
+        throw new Error(`Unknown EBB method: ${method}`);
+    }
+  }
+
+  // Reconnect loop: yields a connected EBB, then null on disconnect, forever.
+  (async () => {
+    for await (const device of ebbs(options.com, hardware)) {
+      if (stopped) break;
+      currentEbb = device;
+      if (device) device.changeHardware(hardware);
+      postToMain({ kind: "dev", connected: device != null, path: device ? portPath(device) : null, hardware });
+    }
+  })().catch((e) => {
+    console.error(`[ebb-worker] connection loop failed: ${(e as Error).message}`);
+  });
+
+  return {
+    handleMessage(msg: MainToWorker): void {
+      if (msg.kind === "cancel") {
+        currentEbb?.cancel();
+        return;
+      }
+      // msg.kind === "call"
+      dispatch(msg.method, msg.args).then(
+        (value) => postToMain({ kind: "result", id: msg.id, value }),
+        (error: Error) => postToMain({ kind: "error", id: msg.id, error: error?.message ?? String(error) }),
+      );
+    },
+    async terminate(): Promise<void> {
+      stopped = true;
+      try {
+        await currentEbb?.close();
+      } catch {
+        // best effort
+      }
+    },
+  };
+}
+
+// Self-wire when launched as a worker_thread. Importing this module on the main
+// thread (e.g. the in-process transport under vitest) is a no-op here.
+async function wireWorkerThread(): Promise<void> {
+  const { isMainThread, parentPort, workerData } = await import("node:worker_threads");
+  if (isMainThread || !parentPort) return;
+  const port = parentPort;
+  const host = createEbbHost(workerData as EbbHostOptions, (msg) => port.postMessage(msg));
+  port.on("message", (msg: MainToWorker) => host.handleMessage(msg));
+}
+
+void wireWorkerThread();

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -1,4 +1,5 @@
 import { type Block, type Motion, PenMotion, type Plan, XYMotion } from "./planning.js";
+import { PlotTelemetry } from "./telemetry.js";
 import { type Vec2, vsub } from "./vec.js";
 
 enum MicrostepMode {
@@ -24,7 +25,7 @@ type EBBCommand =
   | `LM,${number},${number},${number},${number},${number},${number}` // low-level move
 
   // Configure commands
-  | `CU,${number},${number}` // configure user options (e.g. CU,4,n = motion FIFO depth, fw >= 3.0.0)
+  | `CU,${number},${number}` // configure user options (e.g. CU,3,1 = red LED as empty-FIFO indicator, fw >= 2.8.1)
 
   // Servo commands
   | `S2,${number},${number}` // basic servo position
@@ -66,6 +67,7 @@ export class EBB {
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: used in constructor
   private readableClosed: Promise<void>;
   public hardware: Hardware;
+  public telemetry: PlotTelemetry | null;
 
   private microsteppingMode = MicrostepMode.DISABLED;
 
@@ -79,6 +81,9 @@ export class EBB {
     this.port = port;
     this.writer = this.port.writable.getWriter();
     this.commandQueue = [];
+    this.telemetry = process.env.SAXI_TELEMETRY
+      ? new PlotTelemetry(Number(process.env.SAXI_TELEMETRY_QM || 0))
+      : null;
 
     let buffer = "";
 
@@ -148,6 +153,12 @@ export class EBB {
       console.log(`writing: ${str}`);
     }
     const encoder = new TextEncoder();
+    if (this.telemetry) {
+      const t0 = performance.now();
+      const written = this.writer.write(encoder.encode(str));
+      written.then(() => this.telemetry?.recordWrite(performance.now() - t0)).catch(() => {});
+      return written;
+    }
     return this.writer.write(encoder.encode(str));
   }
 
@@ -197,6 +208,29 @@ export class EBB {
     }
   }
 
+  /**
+   * When telemetry is enabled, make the EBB light its red USR LED whenever the
+   * motion FIFO is empty (firmware >= 2.8.1). During a pen-down path the FIFO
+   * should never be empty, so a flickering red LED is the machine itself
+   * reporting buffer underrun, independent of any host-side timing.
+   */
+  public async setFifoLedIndicator(on: boolean): Promise<void> {
+    if (!this.telemetry) return;
+    try {
+      if ((await this.firmwareVersionCompare(2, 8, 1)) >= 0) {
+        await this.command(`CU,3,${on ? 1 : 0}`);
+        if (on) {
+          console.log("[saxi-telemetry] red USR LED on the EBB = FIFO-empty indicator (flicker during a path = underrun)");
+        }
+      } else if (on) {
+        console.log("[saxi-telemetry] firmware < 2.8.1: FIFO LED indicator (CU,3) not available");
+      }
+    } catch (err) {
+      // Diagnostic nicety only; never let it abort a plot.
+      console.log(`[saxi-telemetry] FIFO LED indicator unavailable: ${(err as Error).message}`);
+    }
+  }
+
   /** The board's maximum motion FIFO depth (QU,2; firmware >= 3.0.0). */
   private async maxFifoDepth(): Promise<number> {
     try {
@@ -232,6 +266,7 @@ export class EBB {
       const depth = requested >= 1 ? requested : await this.maxFifoDepth();
       await this.command(`CU,4,${depth}`);
       console.log(`[saxi] EBB motion FIFO depth set to ${depth}`);
+      if (this.telemetry) this.telemetry.fifoDepth = depth;
     } catch (err) {
       console.log(`[saxi] failed to set FIFO depth: ${(err as Error).message}`);
     }
@@ -380,8 +415,27 @@ export class EBB {
    * Note that the LM command is only available starting from EBB firmware version 2.5.3.
    */
   public async executeXYMotionWithLM(plan: XYMotion): Promise<void> {
-    for (const block of plan.blocks) {
-      await this.executeBlockWithLM(block);
+    const telemetry = this.telemetry;
+    telemetry?.beginMotion();
+    const qmInterval = telemetry?.qmInterval ?? 0;
+    let blockIdx = 0;
+    try {
+      for (const block of plan.blocks) {
+        if (telemetry) {
+          const t0 = performance.now();
+          await this.executeBlockWithLM(block);
+          telemetry.recordBlock(block.duration * 1000, performance.now() - t0);
+          blockIdx++;
+          if (qmInterval > 0 && blockIdx % qmInterval === 0) {
+            telemetry.recordQM(await this.query("QM"), blockIdx);
+          }
+        } else {
+          await this.executeBlockWithLM(block);
+        }
+      }
+    } finally {
+      // On cancel the loop throws mid-motion; still report what was measured.
+      telemetry?.endMotion();
     }
   }
 
@@ -445,6 +499,8 @@ export class EBB {
   }
 
   public async executePlan(plan: Plan, microsteppingMode: RunningMicrostepMode = MicrostepMode.EIGHTH): Promise<void> {
+    this.telemetry?.reset();
+    await this.setFifoLedIndicator(true);
     await this.configureFifoDepth();
     await this.enableMotors(microsteppingMode);
 
@@ -453,7 +509,9 @@ export class EBB {
     }
 
     await this.waitUntilMotorsIdle();
+    await this.setFifoLedIndicator(false);
     await this.disableMotors();
+    this.telemetry?.logSummary();
   }
 
   /**

--- a/src/serial-device.ts
+++ b/src/serial-device.ts
@@ -1,0 +1,83 @@
+/**
+ * Serial device discovery and connection helpers for the EBB.
+ *
+ * Extracted from server.ts so the serial worker (ebb-worker.ts) can own port
+ * lifecycle without importing express/ws. The CLI and the worker both use
+ * these; the web server reaches the EBB through ebb-proxy.ts instead.
+ */
+import { autoDetect } from "@serialport/bindings-cpp";
+import type { PortInfo } from "@serialport/bindings-interface";
+import { EBB, type Hardware } from "./ebb.js";
+import { SerialPortSerialPort } from "./serialport-serialport.js";
+import * as _self from "./serial-device.js"; // self-import for test mocking
+
+export type Com = string;
+
+export async function tryOpen(com: Com) {
+  const port = new SerialPortSerialPort(com);
+  await port.open({ baudRate: 9600 });
+  return port;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isEBB(p: PortInfo): boolean {
+  return (
+    p.manufacturer === "SchmalzHaus" ||
+    p.manufacturer === "SchmalzHaus LLC" ||
+    (p.vendorId === "04D8" && p.productId === "FD92")
+  );
+}
+
+export async function listEBBs() {
+  const Binding = autoDetect();
+  const ports = await Binding.list();
+  return ports.filter(isEBB).map((p: { path: string }) => p.path);
+}
+
+export async function waitForEbb(): Promise<Com> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const ebbs = await listEBBs();
+    if (ebbs.length) {
+      return ebbs[0];
+    }
+    await sleep(5000);
+  }
+}
+
+/**
+ * Async generator over the lifetime of EBB connections: yields a connected EBB,
+ * then `null` when it disconnects, then reconnects, forever.
+ */
+export async function* ebbs(path?: string, hardware: Hardware = "v3") {
+  while (true) {
+    try {
+      const com: Com = path || (await _self.waitForEbb()); // use self-import for test mocking
+      console.log(`Found EBB at ${com}`);
+      const port = await tryOpen(com);
+      const closed = new Promise((resolve) => {
+        port.addEventListener("disconnect", resolve, { once: true });
+      });
+      yield new EBB(port, hardware);
+      await closed;
+      yield null;
+      console.error("Lost connection to EBB, reconnecting...");
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      console.error(`Error connecting to EBB: ${err.message}`);
+      console.error("Retrying in 5 seconds...");
+      await sleep(5000);
+    }
+  }
+}
+
+export async function connectEBB(hardware: Hardware, device?: string): Promise<EBB | null> {
+  const dev = device ?? (await listEBBs())[0];
+  if (!dev) return null;
+
+  const port = await tryOpen(dev);
+  return new EBB(port, hardware);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,10 @@ export async function startServer(
   let unpaused: Promise<void> | null = null;
   let signalUnpause: (() => void) | null = null;
   let motionIdx: number | null = null;
-  let currentPlan: Plan | null = null;
+  // The in-progress plan, kept as serialized JSON. Parsed, it is hundreds of
+  // thousands of small objects that every major GC must traverse for the whole
+  // duration of the plot; its only use is being re-sent to websocket clients.
+  let currentPlanJson: string | null = null;
   let plotting = false;
   let controller: AbortController | null = null;
 
@@ -112,8 +115,8 @@ export async function startServer(
     if (motionIdx != null) {
       ws.send(JSON.stringify({ c: "progress", p: { motionIdx } }));
     }
-    if (currentPlan != null) {
-      ws.send(JSON.stringify({ c: "plan", p: { plan: currentPlan } }));
+    if (currentPlanJson != null) {
+      ws.send(`{"c":"plan","p":{"plan":${currentPlanJson}}}`);
     }
 
     ws.on("close", () => {
@@ -135,7 +138,7 @@ export async function startServer(
     const { signal } = controller;
     try {
       const plan = Plan.deserialize(req.body);
-      currentPlan = req.body;
+      currentPlanJson = JSON.stringify(req.body); // once, before motion starts
       console.log(`Received plan of estimated duration ${formatDuration(plan.duration())}`);
       console.log(ebb != null ? "Beginning plot..." : "Simulating plot...");
       res.status(200).end();
@@ -327,7 +330,7 @@ export async function startServer(
       throw err; // propagate real errors
     } finally {
       motionIdx = null;
-      currentPlan = null;
+      currentPlanJson = null;
       await plotter.postPlot();
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,32 +9,20 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { autoDetect } from "@serialport/bindings-cpp";
-import type { PortInfo } from "@serialport/bindings-interface";
 import cors from "cors";
 import type { Request, Response } from "express";
 import express from "express";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
-import { EBB, type Hardware } from "./ebb.js";
+import { createEbbProxy } from "./ebb-proxy.js";
+import type { Hardware } from "./ebb.js";
 import { type Motion, PenMotion, Plan } from "./planning.js";
-import { SerialPortSerialPort } from "./serialport-serialport.js";
-import * as _self from "./server.js"; // use self-import for test mocking
+import { type Com, connectEBB, waitForEbb } from "./serial-device.js";
 import { formatDuration } from "./util.js";
 
-type Com = string;
-
-/**
- * Shorthand for getting the device info, either EBB or com port.
- * @param ebb
- * @param com
- * @returns
- */
-const getDeviceInfo = (ebb: EBB | null, _com: Com) => {
-  // biome-ignore lint/suspicious/noExplicitAny: private member access
-  const portPath = (ebb?.port as any)?._path ?? null;
-  return { path: portPath, hardware: ebb?.hardware };
-};
+// Re-exported for the CLI (saxi plot/pen) and tests, which still talk to the
+// EBB directly rather than through the worker.
+export { connectEBB, waitForEbb };
 
 /**
  * Start the express server.
@@ -64,7 +52,11 @@ export async function startServer(
   const server = http.createServer(app);
   const wss = new WebSocketServer({ server });
 
-  let ebb: EBB | null;
+  // The EBB lives on its own worker thread; ebbProxy mirrors its API on the
+  // main thread. Starting it at boot (not per plot) keeps worker startup off
+  // the plotting path. See PERF_PLAN.md workstream B.
+  const ebbProxy = await createEbbProxy({ com: com ?? undefined, hardware });
+
   let clients: WebSocket[] = [];
   let unpaused: Promise<void> | null = null;
   let signalUnpause: (() => void) | null = null;
@@ -76,6 +68,14 @@ export async function startServer(
   let plotting = false;
   let controller: AbortController | null = null;
 
+  const getDeviceInfo = () => ({
+    path: ebbProxy.devicePath,
+    hardware: ebbProxy.connected ? ebbProxy.hardware : undefined,
+  });
+
+  // The worker reports connect/disconnect (and hardware changes) as `dev` events.
+  ebbProxy.on("dev", () => broadcast({ c: "dev", p: getDeviceInfo() }));
+
   wss.on("connection", (ws) => {
     clients.push(ws);
     ws.on("message", (message) => {
@@ -85,29 +85,29 @@ export async function startServer(
           ws.send(JSON.stringify({ c: "pong" }));
           break;
         case "limp":
-          if (ebb) {
-            ebb.disableMotors();
+          if (ebbProxy.connected) {
+            ebbProxy.disableMotors();
           }
           break;
         case "setPenHeight":
-          if (ebb) {
+          if (ebbProxy.connected) {
             (async () => {
-              if (await ebb.supportsSR()) {
-                await ebb.setServoPowerTimeout(10000, true);
+              if (await ebbProxy.supportsSR()) {
+                await ebbProxy.setServoPowerTimeout(10000, true);
               }
-              await ebb.setPenHeight(msg.p.height, msg.p.rate);
+              await ebbProxy.setPenHeight(msg.p.height, msg.p.rate);
             })();
           }
           break;
         case "changeHardware":
-          ebb?.changeHardware(msg.p.hardware);
-          broadcast({ c: "dev", p: getDeviceInfo(ebb, com) });
+          ebbProxy.changeHardware(msg.p.hardware);
+          broadcast({ c: "dev", p: getDeviceInfo() });
           break;
       }
     });
 
     // send starting params to clients
-    ws.send(JSON.stringify({ c: "dev", p: getDeviceInfo(ebb, com) }));
+    ws.send(JSON.stringify({ c: "dev", p: getDeviceInfo() }));
 
     ws.send(JSON.stringify({ c: "svgio-enabled", p: svgIoApiKey !== "" }));
 
@@ -140,7 +140,7 @@ export async function startServer(
       const plan = Plan.deserialize(req.body);
       currentPlanJson = JSON.stringify(req.body); // once, before motion starts
       console.log(`Received plan of estimated duration ${formatDuration(plan.duration())}`);
-      console.log(ebb != null ? "Beginning plot..." : "Simulating plot...");
+      console.log(ebbProxy.connected ? "Beginning plot..." : "Simulating plot...");
       res.status(200).end();
 
       const begin = Date.now();
@@ -159,7 +159,7 @@ export async function startServer(
         console.log("Wake lock not available on this platform. Ensure your machine does not sleep during plotting");
       }
       try {
-        await doPlot(ebb != null ? realPlotter : simPlotter, plan, signal);
+        await doPlot(ebbProxy.connected ? realPlotter : simPlotter, plan, signal);
         const end = Date.now();
         console.log(`Plot took ${formatDuration((end - begin) / 1000)}`);
       } finally {
@@ -182,7 +182,7 @@ export async function startServer(
       controller.abort();
       controller = null;
     }
-    ebb?.cancel();
+    ebbProxy.cancel();
     if (unpaused) {
       signalUnpause?.();
       broadcast({ c: "pause", p: { paused: false } });
@@ -254,27 +254,27 @@ export async function startServer(
 
   const realPlotter: Plotter = {
     async prePlot(initialPenHeight: number): Promise<void> {
-      ebb.telemetry?.reset();
-      await ebb.setFifoLedIndicator(true);
-      await ebb.configureFifoDepth();
-      await ebb.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
-      await ebb.setPenHeight(initialPenHeight, 1000, 1000);
+      await ebbProxy.resetTelemetry();
+      await ebbProxy.setFifoLedIndicator(true);
+      await ebbProxy.configureFifoDepth();
+      await ebbProxy.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
+      await ebbProxy.setPenHeight(initialPenHeight, 1000, 1000);
     },
     async executeMotion(motion: Motion, _progress: [number, number]): Promise<void> {
-      await ebb.executeMotion(motion);
+      await ebbProxy.executeMotion(motion);
     },
     async postCancel(initialPenHeight: number): Promise<void> {
       // The board may still be executing motion queued in its FIFO; issuing
       // HM while moving makes the steppers grind against whatever they're doing.
-      await ebb.waitUntilMotorsIdle();
-      await ebb.setPenHeight(initialPenHeight, 1000);
-      await ebb.command("HM,4000"); // HM returns carriage home without 3rd and 4th arguments
+      await ebbProxy.waitUntilMotorsIdle();
+      await ebbProxy.setPenHeight(initialPenHeight, 1000);
+      await ebbProxy.command("HM,4000"); // HM returns carriage home without 3rd and 4th arguments
     },
     async postPlot(): Promise<void> {
-      await ebb.waitUntilMotorsIdle();
-      await ebb.setFifoLedIndicator(false);
-      await ebb.disableMotors();
-      ebb.telemetry?.logSummary();
+      await ebbProxy.waitUntilMotorsIdle();
+      await ebbProxy.setFifoLedIndicator(false);
+      await ebbProxy.disableMotors();
+      await ebbProxy.logTelemetrySummary();
     },
   };
 
@@ -344,83 +344,12 @@ export async function startServer(
 
   return new Promise<http.Server>((resolve) => {
     server.listen(port, () => {
-      async function connect() {
-        const devices = ebbs(com, hardware);
-        for await (const device of devices) {
-          ebb = device;
-          broadcast({ c: "dev", p: getDeviceInfo(ebb, com) });
-        }
-      }
-      connect();
+      // The worker started connecting when ebbProxy was created above; its dev
+      // events drive the broadcast. Nothing more to start here.
       const { family, address, port } = server.address() as AddressInfo;
       const addr = `${family === "IPv6" ? `[${address}]` : address}:${port}`;
       console.log(`Server listening on http://${addr}`);
       resolve(server);
     });
   });
-}
-
-async function tryOpen(com: Com) {
-  const port = new SerialPortSerialPort(com);
-  await port.open({ baudRate: 9600 });
-  return port;
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function isEBB(p: PortInfo): boolean {
-  return (
-    p.manufacturer === "SchmalzHaus" ||
-    p.manufacturer === "SchmalzHaus LLC" ||
-    (p.vendorId === "04D8" && p.productId === "FD92")
-  );
-}
-
-async function listEBBs() {
-  const Binding = autoDetect();
-  const ports = await Binding.list();
-  return ports.filter(isEBB).map((p: { path: string }) => p.path);
-}
-
-export async function waitForEbb(): Promise<Com> {
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const ebbs = await listEBBs();
-    if (ebbs.length) {
-      return ebbs[0];
-    }
-    await sleep(5000);
-  }
-}
-
-async function* ebbs(path?: string, hardware: Hardware = "v3") {
-  while (true) {
-    try {
-      const com: Com = path || (await _self.waitForEbb()); // use self-import for test mocking
-      console.log(`Found EBB at ${com}`);
-      const port = await tryOpen(com);
-      const closed = new Promise((resolve) => {
-        port.addEventListener("disconnect", resolve, { once: true });
-      });
-      yield new EBB(port, hardware);
-      await closed;
-      yield null;
-      console.error("Lost connection to EBB, reconnecting...");
-    } catch (e) {
-      const err = e instanceof Error ? e : new Error(String(e));
-      console.error(`Error connecting to EBB: ${err.message}`);
-      console.error("Retrying in 5 seconds...");
-      await sleep(5000);
-    }
-  }
-}
-
-export async function connectEBB(hardware: Hardware, device?: string): Promise<EBB | null> {
-  const dev = device ?? (await listEBBs())[0];
-  if (!dev) return null;
-
-  const port = await tryOpen(dev);
-  return new EBB(port, hardware);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,6 +251,8 @@ export async function startServer(
 
   const realPlotter: Plotter = {
     async prePlot(initialPenHeight: number): Promise<void> {
+      ebb.telemetry?.reset();
+      await ebb.setFifoLedIndicator(true);
       await ebb.configureFifoDepth();
       await ebb.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
       await ebb.setPenHeight(initialPenHeight, 1000, 1000);
@@ -267,7 +269,9 @@ export async function startServer(
     },
     async postPlot(): Promise<void> {
       await ebb.waitUntilMotorsIdle();
+      await ebb.setFifoLedIndicator(false);
       await ebb.disableMotors();
+      ebb.telemetry?.logSummary();
     },
   };
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,269 @@
+/**
+ * Lightweight timing telemetry for diagnosing stuttery plots.
+ *
+ * Each planned motion block is sent to the EBB as one serial command, and the
+ * EBB's motion FIFO is only one command deep (firmware 2.x; 3.x boots the same
+ * way). The machine moves smoothly only if every command's send->OK cycle
+ * completes faster than the previous block executes; otherwise the steppers
+ * run dry between commands and the plot stutters. This module measures exactly
+ * that.
+ *
+ * Enabled via environment variables (see EBB constructor):
+ *   SAXI_TELEMETRY=1       per-motion + end-of-plot timing summaries
+ *   SAXI_TELEMETRY_QM=200  additionally query motor/FIFO status from the
+ *                          machine every N blocks (adds one extra serial
+ *                          round-trip per sample, so it slightly perturbs
+ *                          the thing it measures)
+ */
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function fmtMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(1)}ms`;
+}
+
+/** Cycles longer than planned by more than this margin count as stalls. */
+const STALL_MARGIN_MS = 2;
+
+/** Emit a running progress line every this many blocks within a motion. */
+const PROGRESS_INTERVAL = 5000;
+
+/** Individually log any command cycle that overruns its block by this much. */
+const SLOW_EVENT_MS = 100;
+
+function ts(): string {
+  return new Date().toTimeString().slice(0, 8);
+}
+
+export class PlotTelemetry {
+  /** Sample QM (motor/FIFO status) every this many blocks; 0 = off. */
+  public qmInterval: number;
+
+  /**
+   * Motion FIFO depth configured on the board (set by EBB.configureFifoDepth).
+   * With a deep FIFO, cycles longer than planned mostly mean healthy
+   * backpressure (waiting for queue space), not starvation, so the stall
+   * numbers must be read differently.
+   */
+  public fifoDepth = 1;
+
+  private motionIdx = 0;
+  private plannedMs: number[] = [];
+  private cycleMs: number[] = [];
+  private writeMs: number[] = [];
+
+  // Totals are accumulated per-block (not per-motion) so that a cancelled
+  // plot still reports everything that was measured up to the cancel.
+  private totalBlocks = 0;
+  private totalPlannedMs = 0;
+  private totalCycleMs = 0;
+  private totalStallMs = 0;
+  private totalStallBlocks = 0;
+
+  private qmSamples = 0;
+  private qmFifoEmpty = 0;
+  private qmIdle = 0;
+
+  private lagTimer: ReturnType<typeof setInterval> | null = null;
+  private gcObserver: PerformanceObserver | null = null;
+  private slowEventsSuppressed = 0;
+  private lastSlowEventLog = 0;
+
+  constructor(qmInterval = 0) {
+    this.qmInterval = qmInterval > 0 ? Math.floor(qmInterval) : 0;
+  }
+
+  /**
+   * Start host-side probes that run independently of the serial traffic:
+   * an event-loop lag monitor and (in Node) a GC pause observer. Together
+   * with the per-block timings these tell apart "host froze" (lag + GC lines
+   * coincide with slow blocks) from "serial link is slow" (slow blocks alone).
+   */
+  private startProbes(): void {
+    if (this.lagTimer == null) {
+      let last = performance.now();
+      this.lagTimer = setInterval(() => {
+        const now = performance.now();
+        const lag = now - last - 50;
+        last = now;
+        if (lag > 50) {
+          console.log(`[saxi-telemetry] ${ts()} event-loop stall: ${lag.toFixed(0)}ms`);
+        }
+      }, 50);
+      // Don't keep the process alive for the probe (Node-only API).
+      (this.lagTimer as { unref?: () => void }).unref?.();
+    }
+    if (this.gcObserver == null && typeof PerformanceObserver !== "undefined") {
+      try {
+        const observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            if (entry.duration > 20) {
+              console.log(`[saxi-telemetry] ${ts()} GC pause: ${entry.duration.toFixed(0)}ms`);
+            }
+          }
+        });
+        observer.observe({ entryTypes: ["gc"] });
+        this.gcObserver = observer;
+      } catch {
+        // 'gc' entries unsupported (e.g. browsers); skip.
+        this.gcObserver = null;
+      }
+    }
+  }
+
+  /** Forget everything; call at the start of each plot. */
+  public reset(): void {
+    this.motionIdx = 0;
+    this.plannedMs = [];
+    this.cycleMs = [];
+    this.writeMs = [];
+    this.totalBlocks = 0;
+    this.totalPlannedMs = 0;
+    this.totalCycleMs = 0;
+    this.totalStallMs = 0;
+    this.totalStallBlocks = 0;
+    this.qmSamples = 0;
+    this.qmFifoEmpty = 0;
+    this.qmIdle = 0;
+    this.slowEventsSuppressed = 0;
+    this.lastSlowEventLog = 0;
+    this.startProbes();
+    console.log("[saxi-telemetry] enabled (stall = command cycle exceeding planned block duration)");
+  }
+
+  public beginMotion(): void {
+    this.plannedMs = [];
+    this.cycleMs = [];
+  }
+
+  /**
+   * Record one executed block: its planned duration vs the wall-clock time the
+   * full send->OK command cycle took.
+   */
+  public recordBlock(plannedDurationMs: number, commandCycleMs: number): void {
+    this.plannedMs.push(plannedDurationMs);
+    this.cycleMs.push(commandCycleMs);
+    this.totalBlocks++;
+    this.totalPlannedMs += plannedDurationMs;
+    this.totalCycleMs += commandCycleMs;
+    const over = commandCycleMs - plannedDurationMs;
+    if (over > STALL_MARGIN_MS) {
+      this.totalStallMs += over;
+      this.totalStallBlocks++;
+    }
+    if (over > SLOW_EVENT_MS) {
+      // Rate-limit to one line per second; aggregate the rest.
+      const now = performance.now();
+      if (now - this.lastSlowEventLog > 1000) {
+        const suppressed = this.slowEventsSuppressed > 0 ? ` (+${this.slowEventsSuppressed} more in the last second)` : "";
+        console.log(
+          `[saxi-telemetry] ${ts()} slow block: cycle ${fmtMs(commandCycleMs)} vs planned ${fmtMs(plannedDurationMs)} ` +
+            `at motion ${this.motionIdx + 1} block ${this.cycleMs.length}${suppressed}`,
+        );
+        this.lastSlowEventLog = now;
+        this.slowEventsSuppressed = 0;
+      } else {
+        this.slowEventsSuppressed++;
+      }
+    }
+    if (this.cycleMs.length % PROGRESS_INTERVAL === 0) {
+      console.log(
+        `[saxi-telemetry] motion ${this.motionIdx + 1} progress: ${this.cycleMs.length} blocks | ` +
+          `plot-wide stalled blocks so far: ${this.totalStallBlocks} totaling ${fmtMs(this.totalStallMs)}`,
+      );
+    }
+  }
+
+  /** Record how long a serial write took to be accepted by the OS driver. */
+  public recordWrite(ms: number): void {
+    this.writeMs.push(ms);
+  }
+
+  /**
+   * Record a QM response sampled mid-motion. At that point the machine should
+   * be busy (command executing, FIFO occupied); an idle response is
+   * machine-side proof of a buffer underrun, and "executing with empty FIFO"
+   * means the buffer is on the verge of running dry.
+   */
+  public recordQM(response: string, blockIdx: number): void {
+    const [, commandStatus, , , fifoStatus] = response.split(",");
+    this.qmSamples++;
+    if (fifoStatus === "0") this.qmFifoEmpty++;
+    if (commandStatus === "0") {
+      this.qmIdle++;
+      console.log(`[saxi-telemetry] QM @ motion ${this.motionIdx + 1} block ${blockIdx}: machine IDLE mid-path (underrun confirmed)`);
+    }
+  }
+
+  /** Print stats for the current motion; safe to call after a cancel. */
+  public endMotion(): void {
+    const n = this.cycleMs.length;
+    this.motionIdx++;
+    // Pen-up travel moves are also XY motions; only report on substantial ones.
+    if (n < 10) return;
+
+    let planned = 0;
+    let cycle = 0;
+    let stallMs = 0;
+    let stallBlocks = 0;
+    for (let i = 0; i < n; i++) {
+      planned += this.plannedMs[i];
+      cycle += this.cycleMs[i];
+      const over = this.cycleMs[i] - this.plannedMs[i];
+      if (over > STALL_MARGIN_MS) {
+        stallMs += over;
+        stallBlocks++;
+      }
+    }
+
+    const sorted = [...this.cycleMs].sort((a, b) => a - b);
+    console.log(
+      `[saxi-telemetry] motion ${this.motionIdx}: ${n} blocks | ` +
+        `planned ${fmtMs(planned)}, actual ${fmtMs(cycle)} (${cycle >= planned ? "+" : ""}${fmtMs(cycle - planned)}) | ` +
+        `stalled blocks: ${stallBlocks} (${((stallBlocks / n) * 100).toFixed(1)}%) totaling ${fmtMs(stallMs)} | ` +
+        `cycle p50 ${fmtMs(percentile(sorted, 50))} p95 ${fmtMs(percentile(sorted, 95))} max ${fmtMs(sorted[n - 1])}`,
+    );
+  }
+
+  /** Print the whole-plot summary; call once plotting finishes or is cancelled. */
+  public logSummary(): void {
+    if (this.totalBlocks === 0) return;
+    const behind = this.totalCycleMs - this.totalPlannedMs;
+    console.log(
+      `[saxi-telemetry] PLOT SUMMARY: ${this.totalBlocks} blocks | ` +
+        `planned ${fmtMs(this.totalPlannedMs)}, actual ${fmtMs(this.totalCycleMs)} ` +
+        `(${behind >= 0 ? "+" : ""}${((behind / Math.max(1, this.totalPlannedMs)) * 100).toFixed(1)}% vs plan) | ` +
+        `stalled blocks: ${this.totalStallBlocks} (${((this.totalStallBlocks / this.totalBlocks) * 100).toFixed(1)}%), ` +
+        `total stall time ${fmtMs(this.totalStallMs)}`,
+    );
+    if (this.writeMs.length > 0) {
+      const sorted = [...this.writeMs].sort((a, b) => a - b);
+      console.log(
+        `[saxi-telemetry] serial writes: ${sorted.length} | ` +
+          `p50 ${fmtMs(percentile(sorted, 50))} p95 ${fmtMs(percentile(sorted, 95))} max ${fmtMs(sorted[sorted.length - 1])}`,
+      );
+    }
+    if (this.qmSamples > 0) {
+      console.log(
+        `[saxi-telemetry] QM samples: ${this.qmSamples} | ` +
+          `FIFO empty: ${this.qmFifoEmpty} | machine idle mid-path: ${this.qmIdle}`,
+      );
+    }
+    if (this.fifoDepth > 1) {
+      console.log(
+        `[saxi-telemetry] note: FIFO depth is ${this.fifoDepth}, so stalled-block counts mostly reflect ` +
+          "healthy backpressure pacing; judge smoothness by actual-vs-plan, the FIFO LED, and QM idle counts.",
+      );
+    } else if (this.totalStallMs > 1000) {
+      console.log(
+        "[saxi-telemetry] diagnosis hint: significant stall time means command cycles can't keep up with " +
+          "block durations -> the EBB's 1-deep FIFO runs dry between commands (visible as stutter). " +
+          "Shorter blocks (denser SVG paths) make this worse.",
+      );
+    }
+  }
+}

--- a/tools/worker-serial-spike.mjs
+++ b/tools/worker-serial-spike.mjs
@@ -1,0 +1,72 @@
+// De-risking spike for the serial worker: confirm the native serial
+// binding (@serialport/bindings-cpp) loads and can talk to the EBB from inside
+// a worker_thread. Run with the saxi server stopped so the port is free:
+//   node tools/worker-serial-spike.mjs
+//
+// Proves three things, in order: (1) the N-API binding loads in a worker and
+// list() works, (2) the port opens in the worker, (3) a V (version) query
+// round-trips. If any step fails the fallback is a child_process host.
+import { Worker, isMainThread, parentPort } from "node:worker_threads";
+import { fileURLToPath } from "node:url";
+
+const isEBB = (p) =>
+  p.manufacturer === "SchmalzHaus" ||
+  p.manufacturer === "SchmalzHaus LLC" ||
+  (p.vendorId === "04D8" && p.productId === "FD92");
+
+if (isMainThread) {
+  const w = new Worker(fileURLToPath(import.meta.url));
+  w.on("message", (m) => console.log("[main] <-", JSON.stringify(m)));
+  w.on("error", (e) => {
+    console.error("[main] worker threw:", e);
+    process.exitCode = 1;
+  });
+  w.on("exit", (code) => console.log(`[main] worker exited (${code})`));
+} else {
+  const run = async () => {
+    // Step 1: native binding loads + list() in the worker.
+    const { autoDetect } = await import("@serialport/bindings-cpp");
+    const Binding = autoDetect();
+    const ports = await Binding.list();
+    parentPort.postMessage({
+      step: "list",
+      ok: true,
+      ebbs: ports.filter(isEBB).map((p) => p.path),
+      all: ports.map((p) => p.path),
+    });
+
+    const ebb = ports.find(isEBB);
+    if (!ebb) {
+      parentPort.postMessage({ step: "open", skipped: "no EBB connected" });
+      return;
+    }
+
+    // Step 2 + 3: open the port in the worker and round-trip a V query.
+    const { SerialPort } = await import("serialport");
+    await new Promise((resolve) => {
+      const port = new SerialPort({ path: ebb.path, baudRate: 9600 }, (err) => {
+        if (err) {
+          parentPort.postMessage({ step: "open", ok: false, error: String(err.message || err) });
+          return resolve();
+        }
+        parentPort.postMessage({ step: "open", ok: true, path: ebb.path });
+        let buf = "";
+        const done = (msg) => {
+          parentPort.postMessage(msg);
+          try { port.close(() => resolve()); } catch { resolve(); }
+        };
+        const timer = setTimeout(() => done({ step: "V", ok: false, error: "timeout (no reply in 2s)" }), 2000);
+        port.on("data", (d) => {
+          buf += d.toString();
+          if (/[\r\n]/.test(buf)) {
+            clearTimeout(timer);
+            done({ step: "V", ok: true, response: buf.trim() });
+          }
+        });
+        port.write("V\r");
+      });
+      port.on("error", (e) => parentPort.postMessage({ step: "port-error", error: String(e.message || e) }));
+    });
+  };
+  run().catch((e) => parentPort.postMessage({ step: "fatal", error: String((e && e.stack) || e) }));
+}


### PR DESCRIPTION
## Problem

The serial send→OK→send loop that drives the EBB shares the main thread with Express, the WebSocket server, and the V8 heap for the whole plan. Any main-thread stall — a major GC, a mid-plot client (re)connect re-stringifying the plan, OS scheduling — delays the next motion command. At a 1-deep FIFO that's a visible stutter (nornagon/saxi#44). This is the Node equivalent of the dedicated process the Inkscape extension gets for free.

## Change

Move the EBB onto its own worker thread:

- **`ebb-worker.ts`** — owns the serial port, the `EBB` instance, its telemetry, and the reconnect loop. Its own event loop and (tiny) heap, so main-thread GC / Express / ws physically can't stall the send loop.
- **`ebb-rpc.ts`** — the `{id, method, args}` message protocol. Granularity is one RPC per method call (one per *motion*, not per serial command) — a motion's whole block stream runs inside the worker.
- **`ebb-proxy.ts`** — main-thread proxy mirroring the EBB API the server uses. **Dual transport:** a real `worker_thread` in production, an in-process host under vitest (so the serial-port mock and its shared command log keep working without a thread boundary).
- **`serial-device.ts`** — serial discovery/connection helpers (`tryOpen`/`listEBBs`/`waitForEbb`/`ebbs`/`connectEBB`) extracted from `server.ts` so the worker can own port lifecycle without importing Express/ws. `server.ts` re-exports `connectEBB`/`waitForEbb` for the CLI and tests.
- **`server.ts`** — `ebb` becomes `ebbProxy`; the realPlotter drives the worker. Also folds in retaining the in-progress plan as a pre-serialized JSON string (a ~310 ms event-loop stall on a 14.7 MB plan whenever a client reconnected mid-plot).
- **`tools/worker-serial-spike.mjs`** — the de-risking spike proving `@serialport/bindings-cpp` loads and talks to the EBB from inside a worker thread.

## Stacking / merge order

> [!IMPORTANT]
> **This is the capstone of the stutter work and should merge last.** It depends on:
> - **#309** (FIFO depth) and **#310** (telemetry) — the proxy forwards `configureFifoDepth` / `setFifoLedIndicator` / `resetTelemetry` / `logTelemetrySummary` to the EBB in the worker.
>
> GitHub can't base a PR here on my fork's branches, so this targets `main` and its diff currently includes the #309/#310 commits and the JSON-plan tweak. As those merge, the diff collapses to the worker code (I'll rebase as needed). Independent of the flat-storage PR (#312). Draft until its prerequisites land.

## Testing

`tsc` (server + ui) and `biome lint` clean; full vitest suite passes (20/21, 1 pre-existing skip), including a new `ebb-proxy.test.ts` and the existing mock-serial `server.test.ts` exercising the full RPC + worker-host path in-process.

**Needs real-hardware verification** of the actual thread boundary (a live plot on an AxiDraw) — the in-process test transport covers the protocol and host logic but not the worker_thread serialization/lifecycle. @go2dev will run that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)