### PR TITLE
perf: run the EBB serial + plot loop off the main thread (unified Web Worker / shared host)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 .eslintcache
 .vscode
 .DS_Store
+
+# full-plot spike build output
+tools/plot-spike/dist/

--- a/build.mjs
+++ b/build.mjs
@@ -20,6 +20,7 @@ const buildOptions = {
     IS_WEB: (process.env.IS_WEB === "1").toString(),
     "process.env.DEBUG_SAXI_COMMANDS": JSON.stringify(process.env.DEBUG_SAXI_COMMANDS ?? ""),
     "process.env.SAXI_FIFO_DEPTH": JSON.stringify(process.env.SAXI_FIFO_DEPTH ?? ""),
+    "process.env.SAXI_TRACE_TIMING": JSON.stringify(process.env.SAXI_TRACE_TIMING ?? ""),
   },
   plugins: [
     inlineWorker(),

--- a/build.mjs
+++ b/build.mjs
@@ -5,7 +5,7 @@ import { build, context } from "esbuild";
 import inlineWorker from "esbuild-plugin-inline-worker";
 
 const buildOptions = {
-  entryPoints: ["src/ui.tsx", "src/background-planner.ts"],
+  entryPoints: ["src/ui.tsx", "src/background-planner.ts", "src/serial-worker.ts"],
   bundle: true,
   platform: "browser",
   target: "es2022",

--- a/src/__tests__/ebb-host.test.ts
+++ b/src/__tests__/ebb-host.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import type { SerialChannel } from "../ebb";
+import { createEbbHost } from "../ebb-host";
+import { AxidrawFast, plan } from "../planning";
+import type { HostEvent } from "../serial-worker-rpc";
+import { createMockSerialPort, mockSerialPortInstance } from "./mocks/serialport";
+
+const samplePlan = () =>
+  plan(
+    [
+      [
+        { x: 10, y: 10 },
+        { x: 20, y: 10 },
+      ],
+    ],
+    AxidrawFast,
+  ).serialize();
+
+describe("ebb-host", () => {
+  test("runs a plot over a SerialChannel and emits progress + finished", async () => {
+    mockSerialPortInstance.clearCommands();
+    const channel = createMockSerialPort() as unknown as SerialChannel;
+    const events: HostEvent[] = [];
+
+    const done = new Promise<void>((resolve) => {
+      const host = createEbbHost(channel, "v3", (event) => {
+        events.push(event);
+        if (event.kind === "finished" || event.kind === "error") resolve();
+      });
+      host.handle({ kind: "plot", plan: samplePlan() });
+    });
+
+    await done;
+
+    expect(events.find((e) => e.kind === "error")).toBeUndefined();
+    expect(events.some((e) => e.kind === "progress")).toBe(true);
+    expect(events.some((e) => e.kind === "finished")).toBe(true);
+    expect(mockSerialPortInstance.commands).toContain("EM,1,1"); // motors enabled
+  });
+
+  test("pauses mid-plot and resumes to completion", async () => {
+    mockSerialPortInstance.clearCommands();
+    const channel = createMockSerialPort() as unknown as SerialChannel;
+    const events: HostEvent[] = [];
+    let pausedOnce = false;
+
+    const done = new Promise<void>((resolve) => {
+      const host = createEbbHost(channel, "v3", (event) => {
+        events.push(event);
+        // Request a pause as soon as the plot starts moving...
+        if (event.kind === "progress" && !pausedOnce) {
+          pausedOnce = true;
+          host.handle({ kind: "pause" });
+        }
+        // ...then resume once the pause has actually taken effect. setTimeout
+        // (a macrotask) lets the pause gate park on its resume wait first.
+        if (event.kind === "paused" && event.paused) {
+          setTimeout(() => host.handle({ kind: "resume" }), 0);
+        }
+        if (event.kind === "finished" || event.kind === "error") resolve();
+      });
+      host.handle({ kind: "plot", plan: samplePlan() });
+    });
+
+    await done;
+
+    expect(events.find((e) => e.kind === "error")).toBeUndefined();
+    expect(events.some((e) => e.kind === "paused" && e.paused === true)).toBe(true);
+    expect(events.some((e) => e.kind === "paused" && e.paused === false)).toBe(true);
+    expect(events.some((e) => e.kind === "finished")).toBe(true);
+  });
+});

--- a/src/drivers.ts
+++ b/src/drivers.ts
@@ -1,5 +1,6 @@
-import { EBB, type Hardware } from "./ebb";
-import { Device, PenMotion, Plan } from "./planning.js";
+import type { Hardware } from "./ebb";
+import { Plan } from "./planning.js";
+import type { HostEvent } from "./serial-worker-rpc.js";
 
 export interface DeviceInfo {
   path: string;
@@ -34,14 +35,18 @@ export abstract class BaseDriver {
 }
 
 /**
- * WebSerial driver for the EBB. Implement interface by connecting directly to the Axi
- * machine. Used on serverless configuration (IS_WEB is set), where the control is handled
- * directly on the browser.
+ * WebSerial driver for the EBB. Connects directly to the Axi machine in the
+ * browser (serverless config, IS_WEB set). The EBB and the whole plot loop run
+ * on a dedicated Web Worker (serial-worker.js): the port is opened here on the
+ * UI thread (navigator.serial requires it), its streams are transferred into
+ * the worker, and from then on the UI thread only posts commands and receives
+ * lifecycle events — so React/GC on the UI thread can't stall the serial loop.
  */
 export class WebSerialDriver extends BaseDriver {
-  private _unpaused: Promise<void> | null = null;
-  private _signalUnpause: (() => void) | null = null;
-  private _cancelRequested = false;
+  public hardware: Hardware;
+  private _name: string;
+  private port: SerialPort;
+  private worker: Worker;
   private _disconnectHandler: ((event: Event) => void) | null = null;
 
   public static async connect(port?: SerialPort, hardware: Hardware = "v3") {
@@ -54,13 +59,12 @@ export class WebSerialDriver extends BaseDriver {
     // (pyserial defaults to 9600)
     await port.open({ baudRate: 9600 });
     const { usbVendorId, usbProductId } = port.getInfo();
-    const ebb = new EBB(port, hardware);
 
     const vendorId = usbVendorId?.toString(16).padStart(4, "0");
     const productId = usbProductId?.toString(16).padStart(4, "0");
     const name = `${vendorId}:${productId}`;
 
-    const driver = new WebSerialDriver(ebb, name);
+    const driver = new WebSerialDriver(port, name, hardware);
     driver._disconnectHandler = (event: Event) => {
       if (event.target === port) {
         driver.handleDisconnection();
@@ -72,16 +76,45 @@ export class WebSerialDriver extends BaseDriver {
     return driver;
   }
 
-  private _name: string;
   public name(): string {
     return this._name;
   }
 
-  public ebb: EBB;
-  private constructor(ebb: EBB, name: string) {
+  private constructor(port: SerialPort, name: string, hardware: Hardware) {
     super();
-    this.ebb = ebb;
+    this.port = port;
     this._name = name;
+    this.hardware = hardware;
+    this.worker = new Worker("serial-worker.js");
+    this.worker.addEventListener("message", (e: MessageEvent<HostEvent>) => this.onEvent(e.data));
+    // Hand the port's streams to the worker; from here it owns the EBB.
+    this.worker.postMessage({ kind: "init", readable: port.readable, writable: port.writable, hardware }, [
+      port.readable,
+      port.writable,
+    ]);
+  }
+
+  private onEvent(event: HostEvent): void {
+    switch (event.kind) {
+      case "progress":
+        this.onprogress(event.motionIdx);
+        break;
+      case "paused":
+        this.onpause(event.paused);
+        break;
+      case "finished":
+        this.onfinished();
+        break;
+      case "cancelled":
+        this.oncancelled();
+        break;
+      case "error":
+        console.error(`[serial-worker] ${event.message}`);
+        break;
+      case "closePort":
+        void this.closePort();
+        break;
+    }
   }
 
   private handleDisconnection(): void {
@@ -89,88 +122,60 @@ export class WebSerialDriver extends BaseDriver {
     this.connected = false;
   }
 
+  /**
+   * The worker released its locks on the transferred streams and asked us to
+   * close the port. The unlock takes a moment to cross the thread boundary, so
+   * retry until close() is accepted.
+   */
+  private async closePort(): Promise<void> {
+    for (let i = 0; i < 100; i++) {
+      try {
+        await this.port.close();
+        return;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    }
+  }
+
   public async close(): Promise<void> {
     this.handleDisconnection();
     if (this._disconnectHandler) {
       navigator.serial.removeEventListener("disconnect", this._disconnectHandler);
     }
-    return this.ebb.close();
+    this.worker.postMessage({ kind: "close" }); // worker tears down the EBB, then emits closePort
   }
 
-  public async plot(plan: Plan): Promise<void> {
-    const microsteppingMode = 1; // 16x microstepping, matches defaults from Axidraw
-    this._unpaused = null;
-    this._cancelRequested = false;
-    await this.ebb.enableMotors(microsteppingMode);
-
-    let motionIdx = 0;
-    let penIsUp = true;
-    for (const motion of plan.motions) {
-      this.onprogress(motionIdx);
-      await this.ebb.executeMotion(motion);
-      if (motion instanceof PenMotion) {
-        penIsUp = motion.initialPos < motion.finalPos;
-      }
-      if (this._unpaused && penIsUp) {
-        await this._unpaused;
-        this.onpause(false);
-      }
-      if (this._cancelRequested) { break; } // biome-ignore format: compactness
-      motionIdx += 1;
-    }
-
-    if (this._cancelRequested) {
-      const device = Device(this.ebb.hardware);
-      if (!penIsUp) {
-        // Move to the pen up position, or 50% if no position was found
-        const penMotion = plan.motions.find((motion): motion is PenMotion => motion instanceof PenMotion);
-        const penUpPosition = penMotion ? Math.max(penMotion.initialPos, penMotion.finalPos) : device.penPctToPos(50);
-        await this.ebb.setPenHeight(penUpPosition, 1000);
-        await this.ebb.command("HM,4000"); // HM returns carriage home without 3rd and 4th arguments
-      }
-      this.oncancelled();
-    } else {
-      this.onfinished();
-    }
-
-    await this.ebb.waitUntilMotorsIdle();
-    await this.ebb.disableMotors();
+  public plot(plan: Plan): void {
+    this.worker.postMessage({ kind: "plot", plan: plan.serialize() });
   }
 
   public cancel(): void {
-    this._cancelRequested = true;
+    this.worker.postMessage({ kind: "cancel" });
   }
 
   public pause(): void {
-    this._unpaused = new Promise((resolve) => {
-      this._signalUnpause = resolve;
-    });
-    this.onpause(true);
+    this.worker.postMessage({ kind: "pause" });
   }
 
   public resume(): void {
-    const signal = this._signalUnpause;
-    this._unpaused = null;
-    this._signalUnpause = null;
-    signal?.();
+    this.worker.postMessage({ kind: "resume" });
   }
 
-  public async setPenHeight(height: number, rate: number): Promise<void> {
-    if (await this.ebb.supportsSR()) {
-      await this.ebb.setServoPowerTimeout(10000, true);
-    }
-    await this.ebb.setPenHeight(height, rate);
+  public setPenHeight(height: number, rate: number): void {
+    this.worker.postMessage({ kind: "setPenHeight", height, rate });
   }
 
   public limp(): void {
-    this.ebb.disableMotors();
+    this.worker.postMessage({ kind: "limp" });
   }
 
   public changeHardware(hardware: Hardware): void {
-    this.ebb.changeHardware(hardware);
+    this.hardware = hardware;
+    this.worker.postMessage({ kind: "changeHardware", hardware });
     this.ondevinfo({
       path: this._name,
-      hardware: hardware,
+      hardware,
       svgIoEnabled: false, // WebSerial doesn't support SVG I/O
     });
   }

--- a/src/drivers.ts
+++ b/src/drivers.ts
@@ -37,40 +37,39 @@ export abstract class BaseDriver {
 /**
  * WebSerial driver for the EBB. Connects directly to the Axi machine in the
  * browser (serverless config, IS_WEB set). The EBB and the whole plot loop run
- * on a dedicated Web Worker (serial-worker.js): the port is opened here on the
- * UI thread (navigator.serial requires it), its streams are transferred into
- * the worker, and from then on the UI thread only posts commands and receives
- * lifecycle events — so React/GC on the UI thread can't stall the serial loop.
+ * on a dedicated Web Worker (serial-worker.js): the UI thread only does the
+ * requestPort() picker (navigator.serial requires a Window gesture), then the
+ * worker re-acquires that port via getPorts() and opens it, so the serial byte
+ * pipe lives on the worker thread. From then on the UI thread only posts
+ * commands and receives lifecycle events — so React/GC on the UI thread can't
+ * stall the serial loop (not even its byte I/O, which transferring the streams
+ * left on the main thread).
  */
 export class WebSerialDriver extends BaseDriver {
   public hardware: Hardware;
   private _name: string;
-  private port: SerialPort;
   private worker: Worker;
-  private _disconnectHandler: ((event: Event) => void) | null = null;
+  /** Resolves when the worker has opened the port; rejects if it couldn't. */
+  private ready: Promise<void>;
+  private resolveReady!: () => void;
+  private rejectReady!: (e: Error) => void;
+  private settled = false;
 
   public static async connect(port?: SerialPort, hardware: Hardware = "v3") {
+    // requestPort() needs a user gesture and is Window-only, so the main thread
+    // does just the picker; the worker re-acquires the port via getPorts() and
+    // opens it, keeping the serial byte pipe on the worker thread.
     if (!port)
       // biome-ignore lint/style/noParameterAssign: trivial
       port = await navigator.serial.requestPort({ filters: [{ usbVendorId: 0x04d8, usbProductId: 0xfd92 }] });
-    // baudRate ref: https://github.com/evil-mad/plotink/blob/a45739b7d41b74d35c1e933c18949ed44c72de0e/plotink/ebb_serial.py#L281
-    // (doesn't specify baud rate)
-    // and https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.__init__
-    // (pyserial defaults to 9600)
-    await port.open({ baudRate: 9600 });
     const { usbVendorId, usbProductId } = port.getInfo();
 
     const vendorId = usbVendorId?.toString(16).padStart(4, "0");
     const productId = usbProductId?.toString(16).padStart(4, "0");
     const name = `${vendorId}:${productId}`;
 
-    const driver = new WebSerialDriver(port, name, hardware);
-    driver._disconnectHandler = (event: Event) => {
-      if (event.target === port) {
-        driver.handleDisconnection();
-      }
-    };
-    navigator.serial.addEventListener("disconnect", driver._disconnectHandler);
+    const driver = new WebSerialDriver(name, hardware, usbVendorId, usbProductId);
+    await driver.ready; // wait for the worker to open the port (throws on failure)
     driver.connected = true;
 
     return driver;
@@ -80,22 +79,37 @@ export class WebSerialDriver extends BaseDriver {
     return this._name;
   }
 
-  private constructor(port: SerialPort, name: string, hardware: Hardware) {
+  private constructor(name: string, hardware: Hardware, usbVendorId?: number, usbProductId?: number) {
     super();
-    this.port = port;
     this._name = name;
     this.hardware = hardware;
+    this.ready = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
     this.worker = new Worker("serial-worker.js");
     this.worker.addEventListener("message", (e: MessageEvent<HostEvent>) => this.onEvent(e.data));
-    // Hand the port's streams to the worker; from here it owns the EBB.
-    this.worker.postMessage({ kind: "init", readable: port.readable, writable: port.writable, hardware }, [
-      port.readable,
-      port.writable,
-    ]);
+    this.worker.addEventListener("error", (e) => {
+      console.error(`[serial-worker] failed to load/run: ${e.message}`);
+      this.settle(() => this.rejectReady(new Error(e.message || "serial worker failed to start")));
+    });
+    this.worker.addEventListener("messageerror", (e) => console.error("[serial-worker] message clone error", e));
+    // The worker opens the port itself; we only tell it which device to find.
+    this.worker.postMessage({ kind: "init", hardware, usbVendorId, usbProductId });
+  }
+
+  /** Resolve/reject `ready` exactly once. */
+  private settle(action: () => void): void {
+    if (this.settled) return;
+    this.settled = true;
+    action();
   }
 
   private onEvent(event: HostEvent): void {
     switch (event.kind) {
+      case "ready":
+        this.settle(() => this.resolveReady());
+        break;
       case "progress":
         this.onprogress(event.motionIdx);
         break;
@@ -110,9 +124,11 @@ export class WebSerialDriver extends BaseDriver {
         break;
       case "error":
         console.error(`[serial-worker] ${event.message}`);
+        // A failure before "ready" means the port never opened — fail connect().
+        this.settle(() => this.rejectReady(new Error(event.message)));
         break;
-      case "closePort":
-        void this.closePort();
+      case "disconnected":
+        this.handleDisconnection();
         break;
     }
   }
@@ -122,28 +138,11 @@ export class WebSerialDriver extends BaseDriver {
     this.connected = false;
   }
 
-  /**
-   * The worker released its locks on the transferred streams and asked us to
-   * close the port. The unlock takes a moment to cross the thread boundary, so
-   * retry until close() is accepted.
-   */
-  private async closePort(): Promise<void> {
-    for (let i = 0; i < 100; i++) {
-      try {
-        await this.port.close();
-        return;
-      } catch {
-        await new Promise((resolve) => setTimeout(resolve, 20));
-      }
-    }
-  }
-
   public async close(): Promise<void> {
     this.handleDisconnection();
-    if (this._disconnectHandler) {
-      navigator.serial.removeEventListener("disconnect", this._disconnectHandler);
-    }
-    this.worker.postMessage({ kind: "close" }); // worker tears down the EBB, then emits closePort
+    // The worker owns the port now, so it tears down the EBB and closes the
+    // port itself — no main-thread close retry needed.
+    this.worker.postMessage({ kind: "close" });
   }
 
   public plot(plan: Plan): void {

--- a/src/ebb-host.ts
+++ b/src/ebb-host.ts
@@ -25,37 +25,74 @@ export function createEbbHost(
   let unpaused: Promise<void> | null = null;
   let signalUnpause: (() => void) | null = null;
   let cancelRequested = false;
+  let paused = false;
 
   async function plot(planData: MotionData[]): Promise<void> {
     const plan = Plan.deserialize(planData);
     unpaused = null;
+    signalUnpause = null;
+    paused = false;
     cancelRequested = false;
+    ebb.resetStop();
+    ebb.clearPause();
+
+    // Pen up/down positions for this plan, used to lift the pen on pause/cancel
+    // and lower it again on resume. EBB doesn't track pen state — the host does.
+    const penMotion = plan.motions.find((m): m is PenMotion => m instanceof PenMotion);
+    const penUpPosition = penMotion
+      ? Math.max(penMotion.initialPos, penMotion.finalPos)
+      : Device(ebb.hardware).penPctToPos(50);
+    const penDownPosition = penMotion
+      ? Math.min(penMotion.initialPos, penMotion.finalPos)
+      : Device(ebb.hardware).penPctToPos(60);
+
+    let penIsUp = true;
+
+    // Pause checkpoint, run both mid-motion (via the EBB pause hook, between LM
+    // blocks) and at motion boundaries. Let the FIFO drain so the machine
+    // actually stops, lift the pen if we paused mid-stroke, wait for resume,
+    // then lower it so the loop carries on from the same position.
+    const pauseGate = async (): Promise<void> => {
+      if (!paused) return;
+      await ebb.waitUntilMotorsIdle();
+      const penWasDown = !penIsUp;
+      if (penWasDown) await ebb.setPenHeight(penUpPosition, 1000);
+      await unpaused;
+      postEvent({ kind: "paused", paused: false });
+      if (penWasDown && !cancelRequested) await ebb.setPenHeight(penDownPosition, 1000);
+    };
+    ebb.setPauseHook(pauseGate);
+
     await ebb.configureFifoDepth(); // firmware >= 3.0.0 FIFO deepening; no-op otherwise
     await ebb.enableMotors(1); // 16x microstepping, matches AxiDraw defaults
 
     let motionIdx = 0;
-    let penIsUp = true;
-    for (const motion of plan.motions) {
-      postEvent({ kind: "progress", motionIdx });
-      await ebb.executeMotion(motion);
-      if (motion instanceof PenMotion) {
-        penIsUp = motion.initialPos < motion.finalPos;
+    try {
+      for (const motion of plan.motions) {
+        postEvent({ kind: "progress", motionIdx });
+        await ebb.executeMotion(motion);
+        if (motion instanceof PenMotion) {
+          penIsUp = motion.initialPos < motion.finalPos;
+        }
+        await pauseGate(); // catch a pause requested at the motion boundary
+        if (cancelRequested) break;
+        motionIdx += 1;
       }
-      if (unpaused && penIsUp) {
-        await unpaused;
-        postEvent({ kind: "paused", paused: false });
-      }
-      if (cancelRequested) break;
-      motionIdx += 1;
+    } catch (e) {
+      // Cancellation unwinds cooperatively (no throw); swallow any error that
+      // races in during a cancel, but surface real plot failures.
+      if (!cancelRequested) throw e;
+    } finally {
+      ebb.setPauseHook(null);
     }
 
     if (cancelRequested) {
+      // requestStop() stopped the host sending, but the board may still be
+      // draining its motion FIFO; let it stop before homing, or HM grinds
+      // against the buffered moves (a deep FIFO widens that window).
+      await ebb.waitUntilMotorsIdle();
       if (!penIsUp) {
         // Lift the pen before homing, or it drags across the work on the way back.
-        const penMotion = plan.motions.find((m): m is PenMotion => m instanceof PenMotion);
-        const penUpPosition = penMotion
-          ? Math.max(penMotion.initialPos, penMotion.finalPos)
-          : Device(ebb.hardware).penPctToPos(50);
         await ebb.setPenHeight(penUpPosition, 1000);
         await ebb.command("HM,4000"); // home without 3rd/4th args
       }
@@ -68,6 +105,22 @@ export function createEbbHost(
     await ebb.disableMotors();
   }
 
+  function requestCancel(): void {
+    cancelRequested = true;
+    // Cooperatively stop the streaming loop after the current block, so the
+    // current motion returns promptly without leaving its (possibly huge) tail
+    // of blocks to send. This keeps the command stream in sync (unlike
+    // cancel()), so the post-cancel waitUntilMotorsIdle/home commands work.
+    ebb.requestStop();
+    // If paused, release the gate so the loop can reach the cancel check.
+    paused = false;
+    ebb.clearPause();
+    const signal = signalUnpause;
+    unpaused = null;
+    signalUnpause = null;
+    signal?.();
+  }
+
   async function setPenHeight(height: number, rate: number): Promise<void> {
     if (await ebb.supportsSR()) {
       await ebb.setServoPowerTimeout(10000, true);
@@ -76,13 +129,21 @@ export function createEbbHost(
   }
 
   function pause(): void {
+    if (paused) return;
+    paused = true;
     unpaused = new Promise((resolve) => {
       signalUnpause = resolve;
     });
+    // Trip the between-block checkpoint so the pause takes effect mid-motion,
+    // not just at the next motion boundary.
+    ebb.requestPause();
     postEvent({ kind: "paused", paused: true });
   }
 
   function resume(): void {
+    if (!paused) return;
+    paused = false;
+    ebb.clearPause();
     const signal = signalUnpause;
     unpaused = null;
     signalUnpause = null;
@@ -98,7 +159,7 @@ export function createEbbHost(
           plot(cmd.plan).catch(fail);
           break;
         case "cancel":
-          cancelRequested = true;
+          requestCancel();
           break;
         case "pause":
           pause();

--- a/src/ebb-host.ts
+++ b/src/ebb-host.ts
@@ -1,0 +1,124 @@
+/**
+ * Serial worker host — environment-agnostic.
+ *
+ * Owns an EBB over a SerialChannel and runs the entire plot loop (the same loop
+ * the WebSerial driver and the Node server used to run on their main threads),
+ * driven by messages. Both transports — the browser DOM worker and the Node
+ * worker_thread — build a SerialChannel and hand it here, so the serial
+ * send->OK->send loop runs on the worker's own event loop and heap, where
+ * main-thread React / express / ws / GC cannot stall it.
+ */
+import { EBB, type Hardware, type SerialChannel } from "./ebb.js";
+import { Device, type MotionData, PenMotion, Plan } from "./planning.js";
+import type { HostCommand, HostEvent } from "./serial-worker-rpc.js";
+
+export interface EbbHost {
+  handle(cmd: HostCommand): void;
+}
+
+export function createEbbHost(
+  channel: SerialChannel,
+  hardware: Hardware,
+  postEvent: (event: HostEvent) => void,
+): EbbHost {
+  const ebb = new EBB(channel, hardware);
+  let unpaused: Promise<void> | null = null;
+  let signalUnpause: (() => void) | null = null;
+  let cancelRequested = false;
+
+  async function plot(planData: MotionData[]): Promise<void> {
+    const plan = Plan.deserialize(planData);
+    unpaused = null;
+    cancelRequested = false;
+    await ebb.configureFifoDepth(); // firmware >= 3.0.0 FIFO deepening; no-op otherwise
+    await ebb.enableMotors(1); // 16x microstepping, matches AxiDraw defaults
+
+    let motionIdx = 0;
+    let penIsUp = true;
+    for (const motion of plan.motions) {
+      postEvent({ kind: "progress", motionIdx });
+      await ebb.executeMotion(motion);
+      if (motion instanceof PenMotion) {
+        penIsUp = motion.initialPos < motion.finalPos;
+      }
+      if (unpaused && penIsUp) {
+        await unpaused;
+        postEvent({ kind: "paused", paused: false });
+      }
+      if (cancelRequested) break;
+      motionIdx += 1;
+    }
+
+    if (cancelRequested) {
+      if (!penIsUp) {
+        // Lift the pen before homing, or it drags across the work on the way back.
+        const penMotion = plan.motions.find((m): m is PenMotion => m instanceof PenMotion);
+        const penUpPosition = penMotion
+          ? Math.max(penMotion.initialPos, penMotion.finalPos)
+          : Device(ebb.hardware).penPctToPos(50);
+        await ebb.setPenHeight(penUpPosition, 1000);
+        await ebb.command("HM,4000"); // home without 3rd/4th args
+      }
+      postEvent({ kind: "cancelled" });
+    } else {
+      postEvent({ kind: "finished" });
+    }
+
+    await ebb.waitUntilMotorsIdle();
+    await ebb.disableMotors();
+  }
+
+  async function setPenHeight(height: number, rate: number): Promise<void> {
+    if (await ebb.supportsSR()) {
+      await ebb.setServoPowerTimeout(10000, true);
+    }
+    await ebb.setPenHeight(height, rate);
+  }
+
+  function pause(): void {
+    unpaused = new Promise((resolve) => {
+      signalUnpause = resolve;
+    });
+    postEvent({ kind: "paused", paused: true });
+  }
+
+  function resume(): void {
+    const signal = signalUnpause;
+    unpaused = null;
+    signalUnpause = null;
+    signal?.();
+  }
+
+  const fail = (e: unknown) => postEvent({ kind: "error", message: e instanceof Error ? e.message : String(e) });
+
+  return {
+    handle(cmd: HostCommand): void {
+      switch (cmd.kind) {
+        case "plot":
+          plot(cmd.plan).catch(fail);
+          break;
+        case "cancel":
+          cancelRequested = true;
+          break;
+        case "pause":
+          pause();
+          break;
+        case "resume":
+          resume();
+          break;
+        case "setPenHeight":
+          setPenHeight(cmd.height, cmd.rate).catch(fail);
+          break;
+        case "limp":
+          ebb.disableMotors().catch(fail);
+          break;
+        case "changeHardware":
+          ebb.changeHardware(cmd.hardware);
+          break;
+        case "close":
+          ebb.close().catch(fail);
+          break;
+      }
+    },
+  };
+}

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -55,6 +55,86 @@ function modf(d: number): [number, number] {
 export type Hardware = "v3" | "brushless" | "nextdraw-2234";
 
 /**
+ * Opt-in (SAXI_TRACE_TIMING=1) per-block timing trace for the LM streaming loop.
+ *
+ * It separates the two sources of motion gaps so we can tell which one is
+ * stuttering: the host-side `gap` (time between one block's OK and sending the
+ * next — where a GC / event-loop / main-thread stall lands) versus the `rtt`
+ * (the LM command's send->OK round-trip, which is board+serial bound, and at a
+ * 1-deep FIFO also includes waiting for the single slot to free). At FIFO depth
+ * 1 a smooth plot needs gap≈0; any host gap directly starves the steppers.
+ */
+class BlockTimingTrace {
+  private static readonly STALL_MS = 4; // a host gap over this would empty a 1-deep FIFO
+  private static readonly WINDOW = 1000; // blocks per rolling summary line
+
+  static maybeStart(): BlockTimingTrace | null {
+    return process.env.SAXI_TRACE_TIMING ? new BlockTimingTrace() : null;
+  }
+
+  private count = 0;
+  private sumPlanned = 0;
+  private sumRtt = 0;
+  private sumGap = 0;
+  private maxGap = 0;
+  private maxRtt = 0;
+  private stalls = 0;
+  private windowStart = 0;
+  private windowGapSum = 0;
+  private windowMaxGap = 0;
+  private windowRttSum = 0;
+  private windowMaxRtt = 0;
+
+  record(index: number, plannedMs: number, rttMs: number, gapMs: number): void {
+    this.count += 1;
+    this.sumPlanned += plannedMs;
+    this.sumRtt += rttMs;
+    this.sumGap += gapMs;
+    if (gapMs > this.maxGap) this.maxGap = gapMs;
+    if (rttMs > this.maxRtt) this.maxRtt = rttMs;
+    this.windowGapSum += Math.max(0, gapMs);
+    if (gapMs > this.windowMaxGap) this.windowMaxGap = gapMs;
+    this.windowRttSum += rttMs;
+    if (rttMs > this.windowMaxRtt) this.windowMaxRtt = rttMs;
+
+    if (gapMs > BlockTimingTrace.STALL_MS) {
+      this.stalls += 1;
+      console.log(
+        `[timing] block ${index}: host gap ${gapMs.toFixed(1)}ms ` +
+          `(planned move ${plannedMs.toFixed(1)}ms, rtt ${rttMs.toFixed(1)}ms) — FIFO would run dry here`,
+      );
+    }
+    if (index - this.windowStart >= BlockTimingTrace.WINDOW) {
+      const n = index - this.windowStart;
+      console.log(
+        `[timing] blocks ${this.windowStart}-${index}: ` +
+          `host gap ${this.windowGapSum.toFixed(0)}ms total (max ${this.windowMaxGap.toFixed(1)}ms) | ` +
+          `rtt mean ${(this.windowRttSum / n).toFixed(1)}ms (max ${this.windowMaxRtt.toFixed(1)}ms)`,
+      );
+      this.windowStart = index;
+      this.windowGapSum = 0;
+      this.windowMaxGap = 0;
+      this.windowRttSum = 0;
+      this.windowMaxRtt = 0;
+    }
+  }
+
+  summarize(): void {
+    if (this.count === 0) return;
+    const wallS = (this.sumRtt + this.sumGap) / 1000;
+    const plannedS = this.sumPlanned / 1000;
+    const overheadS = this.sumGap / 1000;
+    console.log(
+      `[timing] XYMotion done: ${this.count} blocks | ` +
+        `planned ${plannedS.toFixed(1)}s, wall ${wallS.toFixed(1)}s, host overhead ${overheadS.toFixed(1)}s | ` +
+        `mean gap ${(this.sumGap / this.count).toFixed(2)}ms (max ${this.maxGap.toFixed(1)}ms), ` +
+        `mean rtt ${(this.sumRtt / this.count).toFixed(2)}ms (max ${this.maxRtt.toFixed(1)}ms) | ` +
+        `host stalls >${BlockTimingTrace.STALL_MS}ms: ${this.stalls}`,
+    );
+  }
+}
+
+/**
  * The minimal serial transport the EBB needs: a byte stream in each direction
  * plus a close hook. A WebSerial/Node `SerialPort` satisfies this structurally,
  * and so does a pair of streams transferred into a worker (see ebb-worker),
@@ -86,6 +166,19 @@ export class EBB {
   private error: Vec2 = { x: 0, y: 0 };
 
   private cachedFirmwareVersion: [number, number, number] | undefined = undefined;
+
+  /** Set by requestStop() to cooperatively end the LM streaming loop between blocks. */
+  private stopRequested = false;
+
+  /** Set by requestPause() to make the LM streaming loop run the pause hook before the next block. */
+  private pauseRequested = false;
+  /**
+   * Host-provided gate the LM streaming loop awaits between blocks when a pause
+   * has been requested. The host uses it to let the motion FIFO drain, lift the
+   * pen, wait for resume, then lower the pen — it owns the pen state, which EBB
+   * doesn't track.
+   */
+  private pauseHook: (() => Promise<void>) | null = null;
 
   public constructor(port: SerialChannel, hardware: Hardware = "v3") {
     this.hardware = hardware;
@@ -287,6 +380,40 @@ export class EBB {
       this.commandQueue.shift()?.reject(new Error("Cancelled"));
     }
   }
+
+  /**
+   * Cooperatively stop the LM streaming loop (executeXYMotionWithLM) after the
+   * current block, leaving the command/response stream in sync. Use this to
+   * abort a plot mid-motion; cancel() rejects in-flight commands and desyncs.
+   */
+  public requestStop(): void {
+    this.stopRequested = true;
+  }
+
+  /** Clear a prior requestStop() before starting a new plot. */
+  public resetStop(): void {
+    this.stopRequested = false;
+  }
+
+  /**
+   * Cooperatively pause the LM streaming loop before the next block (so a pause
+   * takes effect mid-motion, not just at motion boundaries). The loop runs the
+   * registered pause hook, which drains the FIFO, lifts the pen, waits for
+   * resume and lowers the pen — keeping the command/response stream in sync.
+   */
+  public requestPause(): void {
+    this.pauseRequested = true;
+  }
+
+  /** Clear a pending pause request (e.g. before starting a new plot). */
+  public clearPause(): void {
+    this.pauseRequested = false;
+  }
+
+  /** Register the gate the LM streaming loop awaits between blocks when paused. */
+  public setPauseHook(hook: (() => Promise<void>) | null): void {
+    this.pauseHook = hook;
+  }
   public async enableMotors(microsteppingMode: RunningMicrostepMode): Promise<void> {
     this.microsteppingMode = microsteppingMode;
     await this.command(`EM,${microsteppingMode},${microsteppingMode}`);
@@ -424,9 +551,38 @@ export class EBB {
    * Note that the LM command is only available starting from EBB firmware version 2.5.3.
    */
   public async executeXYMotionWithLM(plan: XYMotion): Promise<void> {
+    const trace = BlockTimingTrace.maybeStart();
+    let prevOkAt = trace ? performance.now() : 0;
+    let index = 0;
     for (const block of plan.blocks) {
-      await this.executeBlockWithLM(block);
+      // Cooperative stop: bail out between blocks (after the in-flight command's
+      // OK has been consumed) so response matching stays in sync — unlike
+      // cancel(), which rejects mid-command and desyncs the next reply.
+      if (this.stopRequested) return;
+      // Cooperative pause: same between-block checkpoint, but the host gate
+      // waits for resume (and manages the pen) instead of bailing.
+      if (this.pauseRequested) {
+        this.pauseRequested = false;
+        if (this.pauseHook) await this.pauseHook();
+        if (trace) prevOkAt = performance.now(); // don't count the pause as a host gap
+      }
+      if (trace) {
+        // gap = host-side time between the previous block's OK and sending this
+        // one (where a GC / event-loop stall would starve a 1-deep FIFO);
+        // rtt = the LM command's send->OK round-trip (board + serial bound,
+        // and at FIFO depth 1 it also includes waiting for the slot to free).
+        const sendAt = performance.now();
+        const gap = sendAt - prevOkAt;
+        await this.executeBlockWithLM(block);
+        const okAt = performance.now();
+        trace.record(index, block.duration * 1000, okAt - sendAt, gap);
+        prevOkAt = okAt;
+      } else {
+        await this.executeBlockWithLM(block);
+      }
+      index += 1;
     }
+    trace?.summarize();
   }
 
   /**

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -75,7 +75,8 @@ export class EBB {
   public port: SerialChannel;
   private commandQueue: CommandGenerator[];
   private writer: WritableStreamDefaultWriter<Uint8Array>;
-  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: used in constructor
+  private reader: ReadableStreamDefaultReader<Uint8Array>;
+  /** Resolves when the read loop has stopped and released its lock. */
   private readableClosed: Promise<void>;
   public hardware: Hardware;
 
@@ -92,47 +93,64 @@ export class EBB {
     this.writer = this.port.writable.getWriter();
     this.commandQueue = [];
 
+    // Read with a raw reader + manual decode (rather than pipeThrough/pipeTo) so
+    // we own the lock on port.readable and can release it deterministically in
+    // close(): close() cancels this reader, the loop ends and releases the lock,
+    // then port.close() can proceed. pipeThrough hid the lock behind a second,
+    // un-awaited pipe, which left the stream locked at close (visible across a
+    // worker stream-transfer as "Cannot cancel a locked stream").
+    this.reader = port.readable.getReader();
+    const reader = this.reader;
+    const decoder = new TextDecoder();
     let buffer = "";
 
-    this.readableClosed = port.readable
-      .pipeThrough(new TextDecoderStream() as TransformStream<Uint8Array, string>)
-      .pipeTo(
-        new WritableStream({
-          write: (chunk) => {
-            buffer += chunk;
-            const parts = buffer.split(/[\r\n]+/); // each command is on a different line
-            buffer = parts.pop() || "";
+    this.readableClosed = (async () => {
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const parts = buffer.split(/[\r\n]+/); // each command is on a different line
+          buffer = parts.pop() || "";
 
-            for (const part of parts) {
-              if (part.trim() === "") continue; // empty line
-              if (this.commandQueue.length) {
-                if (part[0] === "!") {
-                  // error from EBB
-                  this.commandQueue.shift()?.reject(new Error(part));
-                  continue;
-                }
-
-                try {
-                  const d = this.commandQueue[0].next(part);
-                  if (d.done) {
-                    this.commandQueue.shift()?.resolve(d.value);
-                  }
-                } catch (e) {
-                  this.commandQueue.shift()?.reject(e as Error);
-                }
-              } else {
-                console.log(`unexpected data: ${part}`);
+          for (const part of parts) {
+            if (part.trim() === "") continue; // empty line
+            if (this.commandQueue.length) {
+              if (part[0] === "!") {
+                // error from EBB
+                this.commandQueue.shift()?.reject(new Error(part));
+                continue;
               }
+
+              try {
+                const d = this.commandQueue[0].next(part);
+                if (d.done) {
+                  this.commandQueue.shift()?.resolve(d.value);
+                }
+              } catch (e) {
+                this.commandQueue.shift()?.reject(e as Error);
+              }
+            } else {
+              console.log(`unexpected data: ${part}`);
             }
-          },
-        }),
-      )
-      .catch((error) => {
-        // Swallow premature close error; the disconnect handler takes care of it
-        if (error.code !== "ERR_STREAM_PREMATURE_CLOSE") {
-          throw error;
+          }
         }
-      });
+      } catch (error) {
+        // Premature close (disconnect) or cancel from close(); the disconnect
+        // handler / close() take it from here. Don't reject from this detached
+        // loop (it would surface as an unhandled rejection).
+        const e = error as { code?: string; name?: string };
+        if (e.code !== "ERR_STREAM_PREMATURE_CLOSE" && e.name !== "AbortError") {
+          console.log(`read loop ended: ${(error as Error).message}`);
+        }
+      } finally {
+        try {
+          reader.releaseLock();
+        } catch {
+          // already released
+        }
+      }
+    })();
   }
 
   private get stepMultiplier() {
@@ -148,7 +166,21 @@ export class EBB {
   }
 
   public async close(): Promise<void> {
-    return await this.port.close();
+    // Put both streams into a closed/cancelled state before closing the port,
+    // or port.close() throws on the still-locked streams — including across a
+    // worker stream-transfer, where only a propagating state change (cancel /
+    // abort), not a local releaseLock(), frees the stream for the other realm.
+    // Cancel the reader (the read loop then ends and releases the read lock),
+    // and abort the writer (the write side's analog of cancel).
+    await this.reader.cancel().catch(() => {});
+    await this.readableClosed.catch(() => {});
+    await this.writer.abort().catch(() => {});
+    try {
+      this.writer.releaseLock();
+    } catch {
+      // already released / errored
+    }
+    await this.port.close();
   }
 
   public changeHardware(hardware: Hardware) {

--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -54,13 +54,25 @@ function modf(d: number): [number, number] {
 
 export type Hardware = "v3" | "brushless" | "nextdraw-2234";
 
+/**
+ * The minimal serial transport the EBB needs: a byte stream in each direction
+ * plus a close hook. A WebSerial/Node `SerialPort` satisfies this structurally,
+ * and so does a pair of streams transferred into a worker (see ebb-worker),
+ * which is how the EBB runs off the main thread in the browser build.
+ */
+export interface SerialChannel {
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  close(): Promise<void>;
+}
+
 type CommandGenerator<TReturn = unknown> = Iterator<unknown, TReturn, string> & {
   resolve: (value: TReturn) => void;
   reject: (reason: Error) => void;
 };
 
 export class EBB {
-  public port: SerialPort;
+  public port: SerialChannel;
   private commandQueue: CommandGenerator[];
   private writer: WritableStreamDefaultWriter<Uint8Array>;
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: used in constructor
@@ -74,7 +86,7 @@ export class EBB {
 
   private cachedFirmwareVersion: [number, number, number] | undefined = undefined;
 
-  public constructor(port: SerialPort, hardware: Hardware = "v3") {
+  public constructor(port: SerialChannel, hardware: Hardware = "v3") {
     this.hardware = hardware;
     this.port = port;
     this.writer = this.port.writable.getWriter();

--- a/src/node-ebb-host.ts
+++ b/src/node-ebb-host.ts
@@ -1,0 +1,59 @@
+/**
+ * Main-thread side of the Node serial host (the server's analog of
+ * WebSerialDriver). Builds a SerialChannel over the native serial port and runs
+ * the shared EBB host, surfacing its events via a callback so server.ts can
+ * drive plot/cancel/pause uniformly.
+ *
+ * Note: this runs IN-PROCESS, not on a worker_thread. The WebSerial build runs
+ * the host on a Web Worker, but serialport's native binding faults
+ * ("HandleScope::HandleScope Entering the V8 API without proper locking") the
+ * moment its I/O callbacks fire inside a worker_thread, so the Node loop stays
+ * on the main thread (as it always has upstream). The unification win is the
+ * shared ebb-host; the deep FIFO (#309) is what keeps the main-thread loop
+ * stutter-free. The HostTransport seam leaves room for an out-of-process
+ * (child_process) transport later if true isolation is ever needed.
+ */
+import { createEbbHost } from "./ebb-host.js";
+import type { Hardware, SerialChannel } from "./ebb.js";
+import { SerialPortSerialPort } from "./serialport-serialport.js";
+import type { HostCommand, HostEvent } from "./serial-worker-rpc.js";
+
+export interface HostTransport {
+  /** Forward a command to the EBB host. */
+  handle(cmd: HostCommand): void;
+  /** Tear down the host and release the port. */
+  close(): Promise<void>;
+}
+
+/**
+ * Open the port, build the channel and run the shared host in this process.
+ * Emits "ready" once the port is open (and "disconnected" on unplug), so the
+ * server's connect loop treats it like the browser worker's event stream.
+ */
+export async function createInProcessTransport(
+  com: string,
+  hardware: Hardware,
+  onEvent: (event: HostEvent) => void,
+): Promise<HostTransport> {
+  const serial = new SerialPortSerialPort(com);
+  await serial.open({ baudRate: 9600 });
+  serial.addEventListener("disconnect", () => onEvent({ kind: "disconnected" }), { once: true });
+
+  const channel: SerialChannel = {
+    readable: serial.readable,
+    writable: serial.writable,
+    close: () => serial.close(),
+  };
+  const host = createEbbHost(channel, hardware, onEvent);
+  // The port is already open by the time we return; signal readiness like the worker.
+  queueMicrotask(() => onEvent({ kind: "ready" }));
+
+  return {
+    handle(cmd: HostCommand): void {
+      host.handle(cmd);
+    },
+    async close(): Promise<void> {
+      host.handle({ kind: "close" });
+    },
+  };
+}

--- a/src/serial-worker-rpc.ts
+++ b/src/serial-worker-rpc.ts
@@ -1,0 +1,39 @@
+/**
+ * Message protocol between the UI/server (main thread) and the serial worker.
+ *
+ * The worker owns the EBB and the whole plot loop, so the surface is small:
+ * commands in, lifecycle events out. A plan's entire motion stream runs inside
+ * the worker, so postMessage latency never sits inside the serial send loop.
+ */
+import type { Hardware } from "./ebb.js";
+import type { MotionData } from "./planning.js";
+
+/** Sent into the worker once, before any command, to hand over the port. */
+export interface InitMsg {
+  kind: "init";
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  hardware: Hardware;
+}
+
+/** Commands from the main thread to the worker. */
+export type HostCommand =
+  | { kind: "plot"; plan: MotionData[] }
+  | { kind: "cancel" }
+  | { kind: "pause" }
+  | { kind: "resume" }
+  | { kind: "setPenHeight"; height: number; rate: number }
+  | { kind: "limp" }
+  | { kind: "changeHardware"; hardware: Hardware }
+  | { kind: "close" };
+
+/** Lifecycle events from the worker back to the main thread. */
+export type HostEvent =
+  | { kind: "progress"; motionIdx: number }
+  | { kind: "paused"; paused: boolean }
+  | { kind: "finished" }
+  | { kind: "cancelled" }
+  | { kind: "error"; message: string }
+  // Browser only: the worker has torn the EBB down and released the transferred
+  // streams; the main thread (which owns the SerialPort) should close it.
+  | { kind: "closePort" };

--- a/src/serial-worker-rpc.ts
+++ b/src/serial-worker-rpc.ts
@@ -8,12 +8,19 @@
 import type { Hardware } from "./ebb.js";
 import type { MotionData } from "./planning.js";
 
-/** Sent into the worker once, before any command, to hand over the port. */
+/**
+ * Sent into the worker once, before any command. The main thread only does the
+ * `requestPort()` user gesture (Window-only) and forwards the chosen device's
+ * USB id; the worker re-acquires the port with `navigator.serial.getPorts()`
+ * and opens it itself, so the serial byte pipe lives on the worker thread (not
+ * proxied back through the main thread, which is what transferring the streams
+ * silently did — main-thread jank then starved the board).
+ */
 export interface InitMsg {
   kind: "init";
-  readable: ReadableStream<Uint8Array>;
-  writable: WritableStream<Uint8Array>;
   hardware: Hardware;
+  usbVendorId?: number;
+  usbProductId?: number;
 }
 
 /** Commands from the main thread to the worker. */
@@ -29,11 +36,12 @@ export type HostCommand =
 
 /** Lifecycle events from the worker back to the main thread. */
 export type HostEvent =
+  // The worker found and opened the port; the driver can report "connected".
+  | { kind: "ready" }
   | { kind: "progress"; motionIdx: number }
   | { kind: "paused"; paused: boolean }
   | { kind: "finished" }
   | { kind: "cancelled" }
   | { kind: "error"; message: string }
-  // Browser only: the worker has torn the EBB down and released the transferred
-  // streams; the main thread (which owns the SerialPort) should close it.
-  | { kind: "closePort" };
+  // The port (owned by the worker) was physically unplugged.
+  | { kind: "disconnected" };

--- a/src/serial-worker.ts
+++ b/src/serial-worker.ts
@@ -1,0 +1,32 @@
+/**
+ * Browser serial worker entry (esbuild entry point -> serial-worker.js).
+ *
+ * Receives the WebSerial port's transferred readable/writable streams, wraps
+ * them in a SerialChannel, and runs the shared EBB host here — so the plot's
+ * serial loop runs off the UI thread. close() can't reach the main thread's
+ * SerialPort, so it asks the main thread to close it (by which point the host
+ * has released the stream locks).
+ */
+import { createEbbHost, type EbbHost } from "./ebb-host.js";
+import type { SerialChannel } from "./ebb.js";
+import type { HostCommand, HostEvent, InitMsg } from "./serial-worker-rpc.js";
+
+function post(event: HostEvent): void {
+  (self as unknown as Worker).postMessage(event);
+}
+
+let host: EbbHost | null = null;
+
+self.onmessage = (e: MessageEvent<InitMsg | HostCommand>) => {
+  const msg = e.data;
+  if (msg.kind === "init") {
+    const channel: SerialChannel = {
+      readable: msg.readable,
+      writable: msg.writable,
+      close: async () => post({ kind: "closePort" }),
+    };
+    host = createEbbHost(channel, msg.hardware, post);
+    return;
+  }
+  host?.handle(msg);
+};

--- a/src/serial-worker.ts
+++ b/src/serial-worker.ts
@@ -1,11 +1,12 @@
 /**
  * Browser serial worker entry (esbuild entry point -> serial-worker.js).
  *
- * Receives the WebSerial port's transferred readable/writable streams, wraps
- * them in a SerialChannel, and runs the shared EBB host here — so the plot's
- * serial loop runs off the UI thread. close() can't reach the main thread's
- * SerialPort, so it asks the main thread to close it (by which point the host
- * has released the stream locks).
+ * The worker opens the WebSerial port itself (re-acquiring it via
+ * navigator.serial.getPorts(), since the main thread already obtained
+ * permission with requestPort()) and runs the shared EBB host here. Opening the
+ * port in this realm keeps the serial byte pipe on the worker thread — unlike
+ * transferring port.readable/writable, which leaves the pipe owned by the main
+ * thread and proxies bytes back to it, so main-thread jank starves the board.
  */
 import { createEbbHost, type EbbHost } from "./ebb-host.js";
 import type { SerialChannel } from "./ebb.js";
@@ -17,16 +18,59 @@ function post(event: HostEvent): void {
 
 let host: EbbHost | null = null;
 
+/** Find the authorized port matching the device the user picked on the main thread. */
+async function findPort(msg: InitMsg): Promise<SerialPort> {
+  if (!navigator.serial) {
+    throw new Error("Web Serial is not available in this worker");
+  }
+  const ports = await navigator.serial.getPorts();
+  const matches = ports.filter((p) => {
+    const info = p.getInfo();
+    return (
+      (msg.usbVendorId === undefined || info.usbVendorId === msg.usbVendorId) &&
+      (msg.usbProductId === undefined || info.usbProductId === msg.usbProductId)
+    );
+  });
+  if (matches.length === 0) {
+    throw new Error("Worker could not re-acquire the serial port (no authorized port matched)");
+  }
+  if (matches.length > 1) {
+    console.warn(`[serial-worker] ${matches.length} authorized ports match; opening the first`);
+  }
+  return matches[0];
+}
+
+async function init(msg: InitMsg): Promise<void> {
+  const port = await findPort(msg);
+  // baudRate ref: pyserial defaults to 9600; the EBB is USB CDC so it's nominal.
+  await port.open({ baudRate: 9600 });
+
+  // The worker owns the port, so it detects unplug and closes directly — no
+  // round-trip to the main thread (which is why the old closePort hack is gone).
+  navigator.serial.addEventListener("disconnect", (e: Event) => {
+    if (e.target === port) post({ kind: "disconnected" });
+  });
+
+  const channel: SerialChannel = {
+    readable: port.readable,
+    writable: port.writable,
+    close: async () => {
+      await port.close();
+    },
+  };
+  host = createEbbHost(channel, msg.hardware, post);
+  post({ kind: "ready" });
+}
+
 self.onmessage = (e: MessageEvent<InitMsg | HostCommand>) => {
   const msg = e.data;
   if (msg.kind === "init") {
-    const channel: SerialChannel = {
-      readable: msg.readable,
-      writable: msg.writable,
-      close: async () => post({ kind: "closePort" }),
-    };
-    host = createEbbHost(channel, msg.hardware, post);
+    init(msg).catch((err) => post({ kind: "error", message: err instanceof Error ? err.message : String(err) }));
     return;
   }
-  host?.handle(msg);
+  if (!host) {
+    console.error("[serial-worker] command before init:", msg.kind);
+    return;
+  }
+  host.handle(msg);
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,24 +17,14 @@ import express from "express";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import { EBB, type Hardware } from "./ebb.js";
-import { type Motion, PenMotion, Plan } from "./planning.js";
+import { createInProcessTransport, type HostTransport } from "./node-ebb-host.js";
+import { type MotionData, PenMotion, Plan } from "./planning.js";
+import type { HostEvent } from "./serial-worker-rpc.js";
 import { SerialPortSerialPort } from "./serialport-serialport.js";
 import * as _self from "./server.js"; // use self-import for test mocking
 import { formatDuration } from "./util.js";
 
 type Com = string;
-
-/**
- * Shorthand for getting the device info, either EBB or com port.
- * @param ebb
- * @param com
- * @returns
- */
-const getDeviceInfo = (ebb: EBB | null, _com: Com) => {
-  // biome-ignore lint/suspicious/noExplicitAny: private member access
-  const portPath = (ebb?.port as any)?._path ?? null;
-  return { path: portPath, hardware: ebb?.hardware };
-};
 
 /**
  * Start the express server.
@@ -64,14 +54,29 @@ export async function startServer(
   const server = http.createServer(app);
   const wss = new WebSocketServer({ server });
 
-  let ebb: EBB | null;
+  // The EBB + plot loop now runs off the server's main thread, in the shared
+  // host (see node-ebb-host.ts / serial-worker-node.ts). The server only tracks
+  // device + plot state, forwards commands to the host, and relays its events to
+  // the ws clients. `transport` is null when no device is connected (sim mode).
+  let transport: HostTransport | null = null;
+  let deviceInfo: { path: string | null; hardware: Hardware } = { path: null, hardware };
+  let connected = false;
   let clients: WebSocket[] = [];
-  let unpaused: Promise<void> | null = null;
-  let signalUnpause: (() => void) | null = null;
   let motionIdx: number | null = null;
-  let currentPlan: Plan | null = null;
+  let currentPlan: MotionData[] | null = null;
   let plotting = false;
-  let controller: AbortController | null = null;
+  let paused = false;
+  let plotBegin = 0;
+  let wakeLock: { release(): void } | null = null;
+  let resolveDisconnect: (() => void) | null = null;
+
+  // Simulation-mode plot state (no device): kept entirely in-process. The real
+  // path drives the host instead and never touches these.
+  let simUnpaused: Promise<void> | null = null;
+  let simSignalUnpause: (() => void) | null = null;
+  let simController: AbortController | null = null;
+
+  const devInfo = () => ({ path: deviceInfo.path, hardware: deviceInfo.hardware });
 
   wss.on("connection", (ws) => {
     clients.push(ws);
@@ -82,33 +87,25 @@ export async function startServer(
           ws.send(JSON.stringify({ c: "pong" }));
           break;
         case "limp":
-          if (ebb) {
-            ebb.disableMotors();
-          }
+          transport?.handle({ kind: "limp" });
           break;
         case "setPenHeight":
-          if (ebb) {
-            (async () => {
-              if (await ebb.supportsSR()) {
-                await ebb.setServoPowerTimeout(10000, true);
-              }
-              await ebb.setPenHeight(msg.p.height, msg.p.rate);
-            })();
-          }
+          transport?.handle({ kind: "setPenHeight", height: msg.p.height, rate: msg.p.rate });
           break;
         case "changeHardware":
-          ebb?.changeHardware(msg.p.hardware);
-          broadcast({ c: "dev", p: getDeviceInfo(ebb, com) });
+          deviceInfo = { ...deviceInfo, hardware: msg.p.hardware };
+          transport?.handle({ kind: "changeHardware", hardware: msg.p.hardware });
+          broadcast({ c: "dev", p: devInfo() });
           break;
       }
     });
 
     // send starting params to clients
-    ws.send(JSON.stringify({ c: "dev", p: getDeviceInfo(ebb, com) }));
+    ws.send(JSON.stringify({ c: "dev", p: devInfo() }));
 
     ws.send(JSON.stringify({ c: "svgio-enabled", p: svgIoApiKey !== "" }));
 
-    ws.send(JSON.stringify({ c: "pause", p: { paused: !!unpaused } }));
+    ws.send(JSON.stringify({ c: "pause", p: { paused } }));
     if (motionIdx != null) {
       ws.send(JSON.stringify({ c: "progress", p: { motionIdx } }));
     }
@@ -121,6 +118,78 @@ export async function startServer(
     });
   });
 
+  /** Relay host lifecycle events to the ws clients and track server-side state. */
+  function handleHostEvent(event: HostEvent): void {
+    switch (event.kind) {
+      case "ready":
+        connected = true;
+        broadcast({ c: "dev", p: devInfo() });
+        break;
+      case "progress":
+        motionIdx = event.motionIdx;
+        broadcast({ c: "progress", p: { motionIdx } });
+        break;
+      case "paused":
+        paused = event.paused;
+        broadcast({ c: "pause", p: { paused } });
+        break;
+      case "finished":
+        broadcast({ c: "finished" });
+        endPlot();
+        break;
+      case "cancelled":
+        broadcast({ c: "cancelled" });
+        endPlot();
+        break;
+      case "error":
+        console.error(`[serial-host] ${event.message}`);
+        // Before "ready" this means the port never opened — drop the connection
+        // so the connect loop retries. During a plot, end it so the server unsticks.
+        if (!connected) resolveDisconnect?.();
+        else if (plotting) endPlot();
+        break;
+      case "disconnected":
+        connected = false;
+        // A disconnect mid-plot won't produce finished/cancelled, so end it here
+        // (frees the wake lock and clears `plotting`) before reconnecting.
+        if (plotting) {
+          broadcast({ c: "cancelled" });
+          endPlot();
+        }
+        resolveDisconnect?.();
+        break;
+    }
+  }
+
+  /** Clear plot state once a plot ends (finished / cancelled / failed). */
+  function endPlot(): void {
+    if (plotting) {
+      console.log(`Plot took ${formatDuration((Date.now() - plotBegin) / 1000)}`);
+    }
+    plotting = false;
+    paused = false;
+    motionIdx = null;
+    currentPlan = null;
+    if (wakeLock) {
+      wakeLock.release();
+      wakeLock = null;
+    }
+  }
+
+  async function acquireWakeLock(): Promise<void> {
+    // The wake-lock module is macOS-only.
+    if (process.platform === "darwin") {
+      try {
+        const { WakeLock } = await import("wake-lock");
+        wakeLock = new WakeLock("saxi plotting");
+      } catch (_error) {
+        console.warn("Couldn't acquire wake lock. Ensure your machine does not sleep during plotting");
+      }
+    } else {
+      console.log("Wake lock not available on this platform. Ensure your machine does not sleep during plotting");
+    }
+  }
+
   /**
    * /plot POST endpoint. Receive a plan on the POST body, and execute it.
    */
@@ -130,43 +199,36 @@ export async function startServer(
       res.status(400).send("Plot in progress");
       return;
     }
-    plotting = true;
-    controller = new AbortController();
-    const { signal } = controller;
+    let plan: Plan;
     try {
-      const plan = Plan.deserialize(req.body);
-      currentPlan = req.body;
-      console.log(`Received plan of estimated duration ${formatDuration(plan.duration())}`);
-      console.log(ebb != null ? "Beginning plot..." : "Simulating plot...");
-      res.status(200).end();
+      plan = Plan.deserialize(req.body);
+    } catch (_e) {
+      res.status(500).send("Malformed plan");
+      return;
+    }
 
-      const begin = Date.now();
-      let wakeLock: { release(): void } | null = null;
+    plotting = true;
+    paused = false;
+    motionIdx = 0;
+    currentPlan = req.body;
+    plotBegin = Date.now();
+    console.log(`Received plan of estimated duration ${formatDuration(plan.duration())}`);
+    console.log(transport != null ? "Beginning plot..." : "Simulating plot...");
+    res.status(200).end();
 
-      // The wake-lock module is macOS-only.
-      if (process.platform === "darwin") {
-        try {
-          // Dynamically import wake-lock only on macOS
-          const { WakeLock } = await import("wake-lock");
-          wakeLock = new WakeLock("saxi plotting");
-        } catch (_error) {
-          console.warn("Couldn't acquire wake lock. Ensure your machine does not sleep during plotting");
-        }
-      } else {
-        console.log("Wake lock not available on this platform. Ensure your machine does not sleep during plotting");
-      }
-      try {
-        await doPlot(ebb != null ? realPlotter : simPlotter, plan, signal);
-        const end = Date.now();
-        console.log(`Plot took ${formatDuration((end - begin) / 1000)}`);
-      } finally {
-        if (wakeLock) {
-          wakeLock.release();
-        }
-      }
-    } finally {
-      plotting = false;
-      controller = null;
+    await acquireWakeLock();
+
+    if (transport) {
+      // The worker host runs the whole plot loop and reports back via events
+      // (progress / paused / finished / cancelled), which endPlot()s the server.
+      transport.handle({ kind: "plot", plan: req.body });
+    } else {
+      // No device: simulate the plot in-process so the UI preview still animates.
+      simulatePlot(plan).catch((err) => {
+        console.error("Simulated plot failed:", err);
+        broadcast({ c: "cancelled" });
+        endPlot();
+      });
     }
   });
 
@@ -175,23 +237,28 @@ export async function startServer(
   });
 
   app.post("/cancel", (_req: Request, res: Response) => {
-    if (controller) {
-      controller.abort();
-      controller = null;
+    if (transport) {
+      transport.handle({ kind: "cancel" });
+    } else {
+      // Sim mode: abort the in-process loop and release any pause gate.
+      simController?.abort();
+      simController = null;
+      if (simSignalUnpause) {
+        simSignalUnpause();
+        simSignalUnpause = simUnpaused = null;
+      }
     }
-    ebb?.cancel();
-    if (unpaused) {
-      signalUnpause?.();
-      broadcast({ c: "pause", p: { paused: false } });
-    }
-    unpaused = signalUnpause = null;
     res.status(200).end();
   });
 
   app.post("/pause", (_req: Request, res: Response) => {
-    if (!unpaused) {
-      unpaused = new Promise((resolve) => {
-        signalUnpause = resolve;
+    if (transport) {
+      // The host emits a "paused" event, which broadcasts to the clients.
+      transport.handle({ kind: "pause" });
+    } else if (!simUnpaused) {
+      paused = true;
+      simUnpaused = new Promise((resolve) => {
+        simSignalUnpause = resolve;
       });
       broadcast({ c: "pause", p: { paused: true } });
     }
@@ -199,9 +266,13 @@ export async function startServer(
   });
 
   app.post("/resume", (_req: Request, res: Response) => {
-    if (signalUnpause) {
-      signalUnpause();
-      signalUnpause = unpaused = null;
+    if (transport) {
+      transport.handle({ kind: "resume" });
+    } else if (simSignalUnpause) {
+      paused = false;
+      simSignalUnpause();
+      simSignalUnpause = simUnpaused = null;
+      broadcast({ c: "pause", p: { paused: false } });
     }
     res.status(200).end();
   });
@@ -242,89 +313,45 @@ export async function startServer(
     }
   }
 
-  interface Plotter {
-    prePlot: (initialPenHeight: number) => Promise<void>;
-    executeMotion: (m: Motion, progress: [number, number]) => Promise<void>;
-    postCancel: (initialPenHeight: number) => Promise<void>;
-    postPlot: () => Promise<void>;
-  }
-
-  const realPlotter: Plotter = {
-    async prePlot(initialPenHeight: number): Promise<void> {
-      await ebb.configureFifoDepth();
-      await ebb.enableMotors(1); // 16x microstepping, matches defaults from Axidraw
-      await ebb.setPenHeight(initialPenHeight, 1000, 1000);
-    },
-    async executeMotion(motion: Motion, _progress: [number, number]): Promise<void> {
-      await ebb.executeMotion(motion);
-    },
-    async postCancel(initialPenHeight: number): Promise<void> {
-      // The board may still be executing motion queued in its FIFO; issuing
-      // HM while moving makes the steppers grind against whatever they're doing.
-      await ebb.waitUntilMotorsIdle();
-      await ebb.setPenHeight(initialPenHeight, 1000);
-      await ebb.command("HM,4000"); // HM returns carriage home without 3rd and 4th arguments
-    },
-    async postPlot(): Promise<void> {
-      await ebb.waitUntilMotorsIdle();
-      await ebb.disableMotors();
-    },
-  };
-
-  const simPlotter: Plotter = {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    async prePlot(_initialPenHeight: number): Promise<void> {},
-    async executeMotion(motion: Motion, progress: [number, number]): Promise<void> {
-      console.log(`Motion ${progress[0] + 1}/${progress[1]}`);
-      await new Promise((resolve) => setTimeout(resolve, motion.duration() * 1000));
-    },
-    async postCancel(_initialPenHeight: number): Promise<void> {
-      console.log("Plot cancelled");
-    },
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    async postPlot(): Promise<void> {},
-  };
-
-  async function doPlot(plotter: Plotter, plan: Plan, signal: AbortSignal): Promise<void> {
-    const abortPromise = onceAbort(signal); // reuse abort promise
-    unpaused = null;
-    signalUnpause = null;
-    motionIdx = 0;
-
-    const firstPenMotion = plan.motions.find((x) => x instanceof PenMotion) as PenMotion;
-    await plotter.prePlot(firstPenMotion.initialPos);
+  /**
+   * In-process plot simulation, used only when no device is connected, so the
+   * UI preview still animates. The real path runs the whole loop in the host.
+   */
+  async function simulatePlot(plan: Plan): Promise<void> {
+    const controller = new AbortController();
+    simController = controller;
+    const { signal } = controller;
+    const abort = onceAbort(signal);
 
     let penIsUp = true;
     try {
-      for (const motion of plan.motions) {
+      for (const [i, motion] of plan.motions.entries()) {
+        motionIdx = i;
         broadcast({ c: "progress", p: { motionIdx } });
-
-        await Promise.race([plotter.executeMotion(motion, [motionIdx, plan.motions.length]), abortPromise]);
+        console.log(`Motion ${i + 1}/${plan.motions.length}`);
+        await Promise.race([sleep(motion.duration() * 1000), abort]);
 
         if (motion instanceof PenMotion) {
           penIsUp = motion.initialPos < motion.finalPos;
         }
-
-        if (unpaused && penIsUp) {
-          await Promise.race([unpaused, abortPromise]);
-          broadcast({ c: "pause", p: { paused: false } });
+        // Hold at motion boundaries while paused (only with the pen up, so we
+        // never stop mid-stroke), matching the host's pause behavior.
+        if (simUnpaused && penIsUp) {
+          await Promise.race([simUnpaused, abort]);
         }
-
-        motionIdx += 1;
       }
-
       broadcast({ c: "finished" });
     } catch (err) {
       if (signal.aborted) {
-        await plotter.postCancel(firstPenMotion.initialPos);
+        console.log("Plot cancelled");
         broadcast({ c: "cancelled" });
-        return;
+      } else {
+        throw err;
       }
-      throw err; // propagate real errors
     } finally {
-      motionIdx = null;
-      currentPlan = null;
-      await plotter.postPlot();
+      simController = null;
+      simUnpaused = simSignalUnpause = null;
+      endPlot();
     }
   }
 
@@ -335,16 +362,53 @@ export async function startServer(
     });
   }
 
+  /**
+   * Discover the EBB, hand its serial path to the off-thread host, and keep the
+   * connection alive — reconnecting when the device drops (mirroring the old
+   * ebbs() generator). The host owns the port: a worker_thread in production, or
+   * an in-process host under vitest so the mocked serialport applies.
+   */
+  async function connectLoop(): Promise<void> {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      // Did this attempt reach a live connection? If not (open failed, which the
+      // worker reports as an event rather than a throw), back off before retrying
+      // so a bad/busy port doesn't hot-loop.
+      let everConnected = false;
+      const disconnected = new Promise<void>((resolve) => {
+        resolveDisconnect = resolve;
+      });
+      try {
+        const dev: Com = com || (await _self.waitForEbb()); // self-import for test mocking
+        console.log(`Found EBB at ${dev}`);
+        deviceInfo = { path: dev, hardware: deviceInfo.hardware };
+        // Runs the shared host in-process: serialport's native binding faults
+        // ("HandleScope without locking") when driven from a worker_thread, so
+        // unlike the browser (WebSerial worker) the Node loop stays on the main
+        // thread. The deep FIFO (#309) is what keeps it stutter-free here.
+        transport = await createInProcessTransport(dev, deviceInfo.hardware, handleHostEvent);
+        await disconnected;
+        everConnected = connected;
+        console.error(everConnected ? "Lost connection to EBB, reconnecting..." : "Couldn't open EBB, retrying...");
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        console.error(`Error connecting to EBB: ${err.message}`);
+      } finally {
+        resolveDisconnect = null;
+        connected = false;
+        const t = transport;
+        transport = null;
+        await t?.close().catch(() => {});
+        deviceInfo = { path: null, hardware: deviceInfo.hardware };
+        broadcast({ c: "dev", p: devInfo() });
+      }
+      if (!everConnected) await sleep(5000);
+    }
+  }
+
   return new Promise<http.Server>((resolve) => {
     server.listen(port, () => {
-      async function connect() {
-        const devices = ebbs(com, hardware);
-        for await (const device of devices) {
-          ebb = device;
-          broadcast({ c: "dev", p: getDeviceInfo(ebb, com) });
-        }
-      }
-      connect();
+      connectLoop();
       const { family, address, port } = server.address() as AddressInfo;
       const addr = `${family === "IPv6" ? `[${address}]` : address}:${port}`;
       console.log(`Server listening on http://${addr}`);
@@ -385,28 +449,6 @@ export async function waitForEbb(): Promise<Com> {
       return ebbs[0];
     }
     await sleep(5000);
-  }
-}
-
-async function* ebbs(path?: string, hardware: Hardware = "v3") {
-  while (true) {
-    try {
-      const com: Com = path || (await _self.waitForEbb()); // use self-import for test mocking
-      console.log(`Found EBB at ${com}`);
-      const port = await tryOpen(com);
-      const closed = new Promise((resolve) => {
-        port.addEventListener("disconnect", resolve, { once: true });
-      });
-      yield new EBB(port, hardware);
-      await closed;
-      yield null;
-      console.error("Lost connection to EBB, reconnecting...");
-    } catch (e) {
-      const err = e instanceof Error ? e : new Error(String(e));
-      console.error(`Error connecting to EBB: ${err.message}`);
-      console.error("Retrying in 5 seconds...");
-      await sleep(5000);
-    }
   }
 }
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -842,16 +842,16 @@ function PlotButtons({
   driver: BaseDriver;
 }) {
   function cancel() {
-    driver.cancel();
+    driver?.cancel();
   }
   function pause() {
-    driver.pause();
+    driver?.pause();
   }
   function resume() {
-    driver.resume();
+    driver?.resume();
   }
   function plot(plan: Plan) {
-    driver.plot(plan);
+    driver?.plot(plan);
   }
 
   return (
@@ -864,7 +864,7 @@ function PlotButtons({
         <button
           type="button"
           className={`plot-button ${state.progress != null ? "plot-button--plotting" : ""}`}
-          disabled={plan == null || state.progress != null}
+          disabled={plan == null || state.progress != null || !driver?.connected}
           onClick={() => plan && plot(plan)}
         >
           {plan && state.progress != null ? "Plotting..." : "Plot"}
@@ -1100,6 +1100,8 @@ function PortSelector({ driver, setDriver, hardware }: PortSelectorProps) {
           // get the first
           setDriver(await WebSerialDriver.connect(port, hardware));
         }
+      } catch (e) {
+        console.error("Auto-reconnect to serial device failed:", e);
       } finally {
         setInitializing(false);
       }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1271,7 +1271,7 @@ function Root() {
             <PortSelector
               driver={driver}
               setDriver={setDriver}
-              hardware={(driver as WebSerialDriver)?.ebb?.hardware ?? state.planOptions.hardware}
+              hardware={(driver as WebSerialDriver)?.hardware ?? state.planOptions.hardware}
             />
           )}
           <div className="section-header">pen</div>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -700,29 +700,47 @@ function PlanPreview({
       ? { width: (ps.size.x / ps.size.y) * previewSize.height, height: previewSize.height }
       : { height: (ps.size.y / ps.size.x) * previewSize.width, width: previewSize.width };
 
+  // Time spent in the current motion, used to interpolate the crosshair within
+  // it. Held in a ref so a pause can freeze it and a resume continue from the
+  // same point — otherwise the wall-clock would keep advancing while the
+  // machine is stopped and the preview would race ahead, desyncing on resume.
   const [microprogress, setMicroprogress] = useState(0);
+  const microprogressMs = useRef(0);
+
+  // Restart the within-motion clock at the start of each motion (and clear it
+  // when plotting ends). Keyed only on progress, so pausing doesn't reset it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: progress is a re-run trigger, not read in the body
   useLayoutEffect(() => {
+    microprogressMs.current = 0;
+    setMicroprogress(0);
+  }, [state.progress]);
+
+  // Advance the clock only while plotting and not paused; freeze on pause and
+  // continue from the frozen value on resume.
+  useLayoutEffect(() => {
+    if (state.progress == null || state.paused) {
+      return;
+    }
     let rafHandle: number;
     let cancelled = false;
-    if (state.progress != null) {
-      const startingTime = Date.now();
-      const updateProgress = () => {
-        if (cancelled) {
-          return;
-        }
-        setMicroprogress(Date.now() - startingTime);
-        rafHandle = requestAnimationFrame(updateProgress);
-      };
-      updateProgress();
-    }
+    const base = microprogressMs.current;
+    const startingTime = Date.now();
+    const updateProgress = () => {
+      if (cancelled) {
+        return;
+      }
+      microprogressMs.current = base + (Date.now() - startingTime);
+      setMicroprogress(microprogressMs.current);
+      rafHandle = requestAnimationFrame(updateProgress);
+    };
+    updateProgress();
     return () => {
       cancelled = true;
       if (rafHandle != null) {
         cancelAnimationFrame(rafHandle);
       }
-      setMicroprogress(0);
     };
-  }, [state.progress]);
+  }, [state.progress, state.paused]);
 
   let progressIndicator = <></>;
   if (state.progress != null && plan != null) {

--- a/tools/build-plot-spike.mjs
+++ b/tools/build-plot-spike.mjs
@@ -1,0 +1,25 @@
+// Bundles the full-plot worker spike (tools/plot-spike) for the browser, so it
+// can import the real EBB/planner. Output lands in tools/plot-spike/dist; serve
+// tools/plot-spike over http://localhost and open index.html.
+//
+//   node tools/build-plot-spike.mjs
+//   npx serve tools/plot-spike
+import * as esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: {
+    "spike-main": "tools/plot-spike/spike-main.ts",
+    "spike-worker": "tools/plot-spike/spike-worker.ts",
+  },
+  bundle: true,
+  format: "esm",
+  outdir: "tools/plot-spike/dist",
+  logLevel: "info",
+  define: {
+    IS_WEB: "true",
+    "process.env.DEBUG_SAXI_COMMANDS": '""',
+    "process.env.SAXI_FIFO_DEPTH": '""',
+  },
+});
+
+console.log("built tools/plot-spike/dist — now: npx serve tools/plot-spike");

--- a/tools/plot-spike/index.html
+++ b/tools/plot-spike/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<!--
+  Full-plot spike for the unified serial worker. Runs a real plot through the
+  REAL EBB inside a Web Worker over transferred WebSerial streams, then tears
+  down. Build, then serve over http://localhost (navigator.serial needs it):
+
+      node tools/build-plot-spike.mjs
+      npx serve tools/plot-spike
+      # open the printed http://localhost:<port>/
+
+  WARNING: this MOVES THE CARRIAGE and draws a ~26 mm square. Use scrap paper,
+  or lift/remove the pen to just watch the motion. Keep within reach to power
+  off if needed.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>saxi — full-plot worker spike</title>
+    <style>
+      body { font: 14px/1.5 system-ui, sans-serif; margin: 2rem; max-width: 50rem; }
+      button { font-size: 1rem; padding: 0.5rem 1rem; }
+      #log { white-space: pre-wrap; background: #111; color: #0f0; padding: 1rem; margin-top: 1rem; border-radius: 6px; min-height: 4rem; }
+      .err { color: #f55; }
+      .warn { background: #fee; border: 1px solid #f99; padding: 0.5rem 1rem; border-radius: 6px; }
+    </style>
+  </head>
+  <body>
+    <h1>saxi — full-plot worker spike</h1>
+    <p class="warn">
+      ⚠️ This moves the carriage and draws a ~26&nbsp;mm square. Use scrap paper or lift the pen.
+    </p>
+    <p>
+      Plans a tiny square, opens the EBB, transfers its serial streams into a Web Worker, and lets the worker
+      run the entire plot and tear down — the main thread does no serial I/O during the plot.
+    </p>
+    <button id="go">Plan &amp; plot via worker</button>
+    <div id="log"></div>
+    <script type="module" src="./dist/spike-main.js"></script>
+  </body>
+</html>

--- a/tools/plot-spike/spike-main.ts
+++ b/tools/plot-spike/spike-main.ts
@@ -1,0 +1,99 @@
+/**
+ * Full-plot spike — main thread.
+ *
+ * Plans a tiny (~26 mm) square with the REAL planner, opens the EBB with
+ * navigator.serial, transfers the port's streams + the serialized plan into a
+ * Web Worker, and lets the worker drive the whole plot. The main thread does no
+ * serial I/O during the plot — exactly the unified-worker design. On teardown
+ * the worker releases its stream locks, then signals us to close the port.
+ */
+import type { Path } from "flatten-svg";
+import { defaultPlanOptions } from "../../src/planning";
+import { replan } from "../../src/massager";
+
+const logEl = document.getElementById("log") as HTMLDivElement;
+function log(msg: string, isError = false): void {
+  const line = document.createElement("div");
+  if (isError) line.className = "err";
+  line.textContent = msg;
+  logEl.appendChild(line);
+}
+
+// A ~26 mm square near the origin (svg user units; ~0.26 mm each).
+const square = {
+  points: [
+    { x: 0, y: 0 },
+    { x: 100, y: 0 },
+    { x: 100, y: 100 },
+    { x: 0, y: 100 },
+    { x: 0, y: 0 },
+  ],
+} as unknown as Path;
+
+// port.close() rejects while either transferred stream is still locked. After
+// the worker releases its locks the unlock takes a moment to cross the thread
+// boundary, so retry the close until it lands (or give up after ~2s).
+async function closePortWhenUnlocked(port: SerialPort): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    try {
+      await port.close();
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+  await port.close(); // final attempt; surface the error if still stuck
+}
+
+document.getElementById("go")?.addEventListener("click", async () => {
+  logEl.textContent = "";
+  if (!("serial" in navigator)) {
+    log("navigator.serial unavailable — use Chrome/Edge over http://localhost.", true);
+    return;
+  }
+  try {
+    log("planning a ~26 mm square…");
+    // fitPage/cropToMargins would scale the square to fill the sheet (~188 mm on
+    // ArchA); disable them so 100 svg units plot at their literal ~26 mm.
+    const plan = replan([square], {
+      ...defaultPlanOptions,
+      layerMode: "all",
+      fitPage: false,
+      cropToMargins: false,
+    });
+    const planData = plan.serialize();
+    log(`plan ready: ${plan.motions.length} motions, ~${plan.duration().toFixed(1)} s`);
+
+    log("requesting port…");
+    const port = await navigator.serial.requestPort({
+      filters: [{ usbVendorId: 0x04d8, usbProductId: 0xfd92 }],
+    });
+    await port.open({ baudRate: 9600 });
+    log("port opened on main thread ✓");
+
+    const worker = new Worker(new URL("./spike-worker.js", import.meta.url), { type: "module" });
+    worker.onmessage = (e: MessageEvent<{ step: string; value: unknown; isError: boolean }>) => {
+      const { step, value, isError } = e.data;
+      log(`[${step}] ${value ?? ""}`, isError);
+      if (step === "closePort") {
+        // The worker released its locks on the transferred streams; that unlock
+        // has to propagate to this realm before port.close() will accept it, so
+        // retry briefly until it does.
+        closePortWhenUnlocked(port).then(
+          () => log("port closed on main thread ✓"),
+          (err) => log(`port close failed: ${err.message}`, true),
+        );
+      }
+      if (step === "done" || step === "error") worker.terminate();
+    };
+    worker.onerror = (e) => log(`worker error: ${e.message}`, true);
+
+    log("transferring streams + plan into worker…");
+    worker.postMessage({ readable: port.readable, writable: port.writable, plan: planData, hardware: "v3" }, [
+      port.readable,
+      port.writable,
+    ]);
+  } catch (err) {
+    log(err instanceof Error ? err.message : String(err), true);
+  }
+});

--- a/tools/plot-spike/spike-worker.ts
+++ b/tools/plot-spike/spike-worker.ts
@@ -1,0 +1,62 @@
+/**
+ * Full-plot spike — worker side.
+ *
+ * Receives the transferred WebSerial streams plus a serialized plan, builds the
+ * REAL EBB from a SerialChannel over those streams, and runs the whole plot
+ * (enable motors -> every motion -> idle -> disable) entirely on this worker's
+ * thread. Finally exercises EBB.close() teardown: it aborts the read pipe and
+ * releases the writer here, then asks the main thread to close the port.
+ *
+ * If this draws the square and closes cleanly, the unified-worker design is
+ * fully de-risked: real EBB, real motion, real teardown, all off the main
+ * thread over transferred streams.
+ */
+import { EBB, type Hardware, type SerialChannel } from "../../src/ebb";
+import { type MotionData, Plan } from "../../src/planning";
+
+interface InitMsg {
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  plan: MotionData[];
+  hardware: Hardware;
+}
+
+function post(step: string, value: unknown, isError = false): void {
+  (self as unknown as Worker).postMessage({ step, value, isError });
+}
+
+self.onmessage = async (e: MessageEvent<InitMsg>) => {
+  const { readable, writable, plan: planData, hardware } = e.data;
+
+  // The worker can't touch the main thread's SerialPort object, so close() just
+  // asks main to close it — by which point EBB.close() has already released the
+  // stream locks here.
+  const channel: SerialChannel = {
+    readable,
+    writable,
+    close: async () => post("closePort", null),
+  };
+
+  try {
+    post("init", "streams received in worker; constructing EBB");
+    const ebb = new EBB(channel, hardware);
+    const plan = Plan.deserialize(planData);
+    post("plan", `${plan.motions.length} motions deserialized`);
+
+    await ebb.configureFifoDepth(); // also exercises the merged FIFO fix in the worker
+    await ebb.enableMotors(1); // 16x microstepping
+    let i = 0;
+    for (const motion of plan.motions) {
+      await ebb.executeMotion(motion);
+      post("progress", `motion ${++i}/${plan.motions.length}`);
+    }
+    await ebb.waitUntilMotorsIdle();
+    await ebb.disableMotors();
+    post("plotted", "all motions executed ✓");
+
+    await ebb.close(); // teardown under test
+    post("done", "EBB closed cleanly from the worker ✓");
+  } catch (err) {
+    post("error", err instanceof Error ? err.message : String(err), true);
+  }
+};

--- a/tools/webserial-worker-spike.html
+++ b/tools/webserial-worker-spike.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<!--
+  De-risking spike for the unified serial worker (browser half).
+
+  Proves the one thing the WebSerial worker design hinges on: that a port opened
+  with navigator.serial on the main thread can have its `readable`/`writable`
+  streams TRANSFERRED into a DOM Worker, and that the EBB command loop
+  (write "cmd\r", read a line back) can then run entirely inside that worker —
+  off the main thread, exactly like background-planner.js.
+
+  navigator.serial needs a secure context, so this must be served over
+  http://localhost (NOT opened as a file://) — localhost is a secure context,
+  so any static server works. From the repo root:
+
+      npx serve tools
+      # then open the printed http://localhost:<port>/webserial-worker-spike.html
+
+  Click "Connect & test", pick the EBB. It runs two read-only queries (V =
+  version, QM = motor/FIFO status) from inside the worker. No motion is sent.
+  If both round-trip, the transfer-streams-to-a-worker approach is sound.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>saxi — WebSerial worker spike</title>
+    <style>
+      body { font: 14px/1.5 system-ui, sans-serif; margin: 2rem; max-width: 50rem; }
+      button { font-size: 1rem; padding: 0.5rem 1rem; }
+      #log { white-space: pre-wrap; background: #111; color: #0f0; padding: 1rem; margin-top: 1rem; border-radius: 6px; }
+      .err { color: #f55; }
+    </style>
+  </head>
+  <body>
+    <h1>saxi — WebSerial worker spike</h1>
+    <p>
+      Opens the EBB on the main thread, transfers its serial streams into a Web Worker,
+      and round-trips <code>V</code> and <code>QM</code> from inside the worker. Read-only — no motion.
+    </p>
+    <button id="go">Connect &amp; test</button>
+    <div id="log"></div>
+
+    <script type="text/worker" id="worker-src">
+      // Runs inside the DOM Worker. Receives the transferred WebSerial streams
+      // and drives the EBB command loop with no main-thread involvement.
+      let writer = null;
+      let reader = null;
+      let buf = "";
+
+      function post(step, value, isError) {
+        self.postMessage({ step, value, isError: !!isError });
+      }
+
+      // Read one CR/LF-delimited line, buffering any over-read for the next call
+      // (the same framing EBB uses).
+      async function readLine() {
+        while (true) {
+          const nl = buf.search(/[\r\n]/);
+          if (nl >= 0) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl).replace(/^[\r\n]+/, "");
+            if (line.length) return line;
+            continue;
+          }
+          const { value, done } = await reader.read();
+          if (done) throw new Error("serial stream closed");
+          buf += value;
+        }
+      }
+
+      async function query(cmd) {
+        await writer.write(new TextEncoder().encode(`${cmd}\r`));
+        return await readLine();
+      }
+
+      self.onmessage = async (e) => {
+        try {
+          const { readable, writable } = e.data;
+          post("transfer", "streams received in worker ✓");
+          writer = writable.getWriter();
+          reader = readable.pipeThrough(new TextDecoderStream()).getReader();
+
+          const version = await query("V");
+          post("V", version);
+
+          const qm = await query("QM");
+          post("QM", qm);
+
+          // Release locks so the main thread can close the port cleanly.
+          await reader.cancel().catch(() => {});
+          await writer.close().catch(() => {});
+          post("done", "worker round-trip complete ✓");
+        } catch (err) {
+          post("error", err && err.message ? err.message : String(err), true);
+        }
+      };
+    </script>
+
+    <script>
+      const logEl = document.getElementById("log");
+      function log(msg, isError) {
+        const line = document.createElement("div");
+        if (isError) line.className = "err";
+        line.textContent = msg;
+        logEl.appendChild(line);
+      }
+
+      document.getElementById("go").addEventListener("click", async () => {
+        logEl.textContent = "";
+        if (!("serial" in navigator)) {
+          log("navigator.serial unavailable — use Chrome/Edge over http://localhost (not file://).", true);
+          return;
+        }
+        try {
+          log("requesting port…");
+          const port = await navigator.serial.requestPort({
+            filters: [{ usbVendorId: 0x04d8, usbProductId: 0xfd92 }],
+          });
+          await port.open({ baudRate: 9600 });
+          log("port opened on main thread ✓");
+
+          const workerSrc = document.getElementById("worker-src").textContent;
+          const worker = new Worker(URL.createObjectURL(new Blob([workerSrc], { type: "text/javascript" })));
+
+          worker.onmessage = (e) => {
+            const { step, value, isError } = e.data;
+            log(`[${step}] ${value}`, isError);
+            if (step === "done" || step === "error") {
+              worker.terminate();
+              // The worker released the stream locks; close the underlying port.
+              port.close().then(
+                () => log("port closed ✓"),
+                (err) => log(`port close failed: ${err.message}`, true),
+              );
+            }
+          };
+          worker.onerror = (e) => log(`worker error: ${e.message}`, true);
+
+          log("transferring readable/writable into worker…");
+          worker.postMessage({ readable: port.readable, writable: port.writable }, [port.readable, port.writable]);
+        } catch (err) {
+          log(err && err.message ? err.message : String(err), true);
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Supersedes #313. Runs the EBB `send -> OK -> send` block stream and the whole plot loop on a shared, environment-agnostic **host** (`ebb-host.ts`), so React / express / ws / JSON / GC can no longer inject a multi-ms stall into the serial cycle — the stall that starves the motion FIFO and produces the audible stutter (pairs with the merged FIFO-depth fix #309).

One host, two transports:

- **WebSerial (GitHub Pages / `IS_WEB`)** — runs on a dedicated **Web Worker** that opens the serial port *itself*. The main thread only does the `requestPort()` user gesture and forwards the device's USB id; the worker re-acquires the port via `navigator.serial.getPorts()` and `open()`s it. This matters: *transferring* `port.readable/writable` into the worker leaves Chromium pumping the byte pipe on the **main thread** (proxied back), so main-thread jank still starved the board. Opening in the worker keeps the byte I/O off-thread — verified at FIFO=1, `rtt` stays flat under a main-thread stressor.
- **Node server** — drives the **same shared host**, but **in-process on the main thread**. `serialport`'s native binding faults (`FATAL ERROR: HandleScope::HandleScope Entering the V8 API without proper locking`) the instant its read/write callbacks fire inside a `worker_thread` (reproduced on hardware; crashes even when the main thread never loads the binding). Main-thread I/O works fine, as it always has. The `HostTransport` seam leaves room for an out-of-process (`child_process`) transport later if true off-thread isolation is wanted on Node (tracked separately as a Windows-compat enhancement).

Also in here:
- **Cooperative cancel** (`requestStop()` — bail between blocks, stream stays in sync) instead of `cancel()` (which rejected the in-flight command and desynced).
- **Mid-motion pause/resume** with pen-lift: a between-block checkpoint drains the FIFO, lifts the pen, waits for resume, lowers it, and continues from the same point.
- **Pause-synced preview**: the progress crosshair freezes while paused instead of racing to the motion's end on wall-clock time.
- `EBB` now constructs from a minimal `SerialChannel` (`{readable, writable, close}`) and owns its read lock (raw `getReader()` + manual decode) so `close()` deterministically releases the port — also fixes a latent "close a connected port" lock bug.

### Verified
- `vitest` green — `server.test.ts` drives the unified host in-process so the existing serial-port mock applies unchanged; new offline `ebb-host` plot/pause/resume coverage.
- `tsc` (server + UI) clean; both bundles build.
- On hardware: plot, cancel (stop / pen-up / home / idle), pause↔resume in sync (machine + preview), connect/disconnect/reconnect — both builds.

### Still TODO before this is merge-ready (why it's a draft)
- [ ] Drop the de-risk **spike commits** from history (transferred-stream spike, plot spike).
- [ ] Decide the fate of the env-gated `BlockTimingTrace` (`SAXI_TRACE_TIMING=1`) — keep or drop.
- [ ] Close/retarget #313.
- [ ] (Follow-up, separate) `child_process` Node transport for true off-thread on platforms where `serialport`-in-`worker_thread` is viable.