### PR TITLE
Fix SVG scaling: attach SVG to document so getCTM() works in flattenSVG

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1377,5 +1377,18 @@ function readSvg(svgString: string): Path[] {
   const doc = parser.parseFromString(svgString, "image/svg+xml");
 
   const svg = doc.querySelector("svg");
-  return flattenSVG(svg);
+  // flattenSVG relies on getCTM(), which returns null on elements that aren't
+  // part of a rendered document. Without it, the viewBox -> width/height
+  // scaling is lost and drawings with a viewBox come out the wrong size, so
+  // temporarily attach the SVG off-screen while flattening.
+  const container = document.createElement("div");
+  container.style.position = "absolute";
+  container.style.left = "99999px";
+  document.body.appendChild(container);
+  try {
+    container.appendChild(document.importNode(svg, true));
+    return flattenSVG(container.querySelector("svg"));
+  } finally {
+    container.remove();
+  }
 }


### PR DESCRIPTION
Commit c2f56ba (#263) switched readSvg from a hidden div to DOMParser. flatten-svg relies on getCTM() to map shape coordinates through parent transforms and the viewBox -> width/height mapping, but getCTM() returns null on elements that aren't part of a rendered document. With a null CTM, flatten-svg falls back to raw untransformed coordinates, so drawings with a viewBox (or group transforms) came out at the wrong size and position.

Keep DOMParser for parsing (it doesn't execute scripts), but temporarily attach the parsed SVG off-screen while flattening so getCTM() returns the correct matrix.


Claude-Session: https://claude.ai/code/session_01XGPW21ecuXiQfXFr8yLYdz